### PR TITLE
Adding broadcast payload to avoid UDP checksum errors 

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -16,6 +16,7 @@ import java.net.InetAddress;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -252,7 +253,10 @@ public class Client {
             url = new URL(master);
         }
 
-        DatagramPacket packet = new DatagramPacket(new byte[0], 0);
+        byte[] buffer = new byte[128];
+        Arrays.fill(buffer, (byte) 1);
+
+        DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
         packet.setAddress(InetAddress.getByName(url != null ? url.getHost()
                 : "255.255.255.255"));
         packet.setPort(Integer.getInteger("jenkins.udp", Integer.getInteger("hudson.udp", 33848)));


### PR DESCRIPTION
Changing broadcast to send a UDP packet payload of 128 bytes instead of 0.  The minimum frame size for a valid ethernet packet is 64 bytes which requires a payload of at least 18 bytes.  More documentation here:  http://communities.vmware.com/thread/336045
