### PR TITLE
Command-line option for specifying Node.Mode (and handling for it on the plugin side)

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -76,6 +76,15 @@ public class Client {
     @Option(name = "-disableSslVerification", usage = "Disables SSL verification in the HttpClient.")
     public boolean disableSslVerification;
 
+    @Option(
+            name = "-mode",
+            usage = "The mode controlling how Jenkins allocates jobs to slaves. Can be either '" + ModeOptionHandler.NORMAL + "' " +
+                    "(utilize this slave as much as possible) or '" + ModeOptionHandler.EXCLUSIVE + "' (leave this machine for tied " +
+                    "jobs only). Default is " + ModeOptionHandler.NORMAL + ".",
+            handler = ModeOptionHandler.class
+    )
+    public String mode = ModeOptionHandler.NORMAL;
+
     @Option(name = "-username", usage = "The Jenkins username for authentication")
     public String username;
 
@@ -367,7 +376,8 @@ public class Client {
                 + param("remoteFsRoot", remoteFsRoot.getAbsolutePath())
                 + param("description", description)
                 + param("labels", labelStr.toString()) + "&secret="
-                + target.secret);
+                + target.secret
+                + param("mode", mode.toUpperCase()));
 
         post.setDoAuthentication(true);
         int responseCode = client.executeMethod(post);

--- a/client/src/main/java/hudson/plugins/swarm/ModeOptionHandler.java
+++ b/client/src/main/java/hudson/plugins/swarm/ModeOptionHandler.java
@@ -1,0 +1,43 @@
+package hudson.plugins.swarm;
+
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.OptionDef;
+import org.kohsuke.args4j.spi.OneArgumentOptionHandler;
+import org.kohsuke.args4j.spi.Setter;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Parses possible node modes: can be either 'normal' or 'exclusive'.
+ *
+ * @author Timur Strekalov
+ */
+public class ModeOptionHandler extends OneArgumentOptionHandler<String> {
+
+    public static final String NORMAL = "normal";
+    public static final String EXCLUSIVE = "exclusive";
+
+    private static final List<String> ACCEPTABLE_VALUES = Arrays.asList(NORMAL, EXCLUSIVE);
+
+    public ModeOptionHandler(final CmdLineParser parser, final OptionDef option, final Setter<? super String> setter) {
+        super(parser, option, setter);
+    }
+
+    @Override
+    public String parse(final String argument) throws NumberFormatException, CmdLineException {
+        final int index = ACCEPTABLE_VALUES.indexOf(argument);
+        if (index == -1) {
+            throw new CmdLineException(owner, "Invalid mode");
+        }
+
+        return argument;
+    }
+
+    @Override
+    public String getDefaultMetaVariable() {
+        return "MODE";
+    }
+
+}

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -26,7 +26,7 @@ public class PluginImpl extends Plugin {
      * Adds a new swarm slave.
      */
     public void doCreateSlave(StaplerRequest req, StaplerResponse rsp, @QueryParameter String name, @QueryParameter String description, @QueryParameter int executors,
-            @QueryParameter String remoteFsRoot, @QueryParameter String labels, @QueryParameter String secret) throws IOException, FormException {
+            @QueryParameter String remoteFsRoot, @QueryParameter String labels, @QueryParameter String secret, @QueryParameter Node.Mode mode) throws IOException, FormException {
 
         if (!getSwarmSecret().equals(secret)) {
             rsp.setStatus(SC_FORBIDDEN);
@@ -44,7 +44,7 @@ public class PluginImpl extends Plugin {
             }
 
             SwarmSlave slave = new SwarmSlave(name, "Swarm slave from " + req.getRemoteHost() + " : " + description,
-                    remoteFsRoot, String.valueOf(executors), "swarm " + Util.fixNull(labels));
+                    remoteFsRoot, String.valueOf(executors), mode, "swarm " + Util.fixNull(labels));
 
             // if this still results in a dupliate, so be it
             synchronized (jenkins) {

--- a/plugin/src/main/java/hudson/plugins/swarm/SwarmSlave.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/SwarmSlave.java
@@ -29,8 +29,8 @@ import java.util.List;
  */
 public class SwarmSlave extends Slave implements EphemeralNode {
 
-    public SwarmSlave(String name, String nodeDescription, String remoteFS, String numExecutors, String label) throws IOException, FormException {
-        super(name, nodeDescription, remoteFS, numExecutors, Mode.NORMAL, label,
+    public SwarmSlave(String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode, String label) throws IOException, FormException {
+        super(name, nodeDescription, remoteFS, numExecutors, mode, label,
                 SELF_CLEANUP_LAUNCHER, RetentionStrategy.NOOP, Collections.<NodeProperty<?>>emptyList());
     }
 


### PR DESCRIPTION
- Added a command-line option to the Client to specify the mode to be
  sent to the master node (either 'normal' or 'exclusive' which
  correspond to values in hudson.model.Node.Mode)
- Added a specific OptionHandler to parse those
- Added another @QueryParameter to hudson.plugins.swarm.PluginImpl to
  make sure the mode gets correctly applied
- Added Mode as a parameter to the SwarmSlave constructor that's being
  called from PluginImpl
