### PR TITLE
JENKINS-19643 - add correct version of codec library into swarm client d...

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>commons-httpclient</artifactId>
             <version>3.1</version>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.8</version>
+        </dependency>
 
     </dependencies>
 </project>


### PR DESCRIPTION
commons-codec 1.2 obtained through transitive dependency is too old and causes problem reported in JENKINS-19643 and likely also JENKINS-20418.
