### PR TITLE
[Fixed JENKINS-21155] Update Swarm plugin to use Jenkins 1.480.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>1.480.3</version>
     </parent>
 
     <artifactId>swarm-plugin</artifactId>


### PR DESCRIPTION
The older dependency on Jenkins 1.424 does not include the latest
versions of the Apache commons httpclient, so it fails on some
remote procedures with codec related messages.

Refer to JENKINS-21155 for an example.
