### PR TITLE
Update args4j dependency and remoting dependency to latest

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -49,12 +49,12 @@
         <dependency>
             <groupId>args4j</groupId>
             <artifactId>args4j</artifactId>
-            <version>2.0.21</version>
+            <version>2.0.26</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>remoting</artifactId>
-            <version>2.32</version>
+            <version>2.34</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
args4j 2.0.21 -> 2.0.26
remoting 2.32 -> 2.34
