### PR TITLE
switch to newer Apache httpclient, update to latest released versions of other libs

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -57,9 +57,9 @@
             <version>2.34</version>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.3</version>
         </dependency>
 	<dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
Switch from Apache commons httpclient (which is end of life) to Apache httpcomponents.

I did not review any API usage of httpclient, rather just switched to use the newer library without any source code changes.
