### PR TITLE
[FIXED JENKINS-22730] Bump remoting to match Jenkins LTS

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>remoting</artifactId>
-            <version>2.32</version>
+            <version>2.36</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Swarm nodes are offlined by Jenkins with the following message:

```
"This node is offline because it uses old slave.jar"
```

Therefore we bump the version of the remoting library to match the one
used in Jenkins LTS (1.544.1).
