### PR TITLE
[FIXED JENKINS-25064] Instead of constructing the toollocation key, just use the existing descriptor

### DIFF
--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -90,11 +90,10 @@ public class PluginImpl extends Plugin {
 				for (ToolInstallation inst : desc.getInstallations()) {
 					if (inst.getName().equals(toolLoc[0])) {
 						found = true;
-						
-						String key = inst.getClass().getCanonicalName().toString() + "$DescriptorImpl@" + inst.getName();
+                        
 						String location = toolLoc[1];
 		
-						ToolLocationNodeProperty.ToolLocation toolLocation = new ToolLocationNodeProperty.ToolLocation(key, location);
+						ToolLocationNodeProperty.ToolLocation toolLocation = new ToolLocationNodeProperty.ToolLocation(desc, inst.getName(), location);
 						result.add(toolLocation);
 					}
 				}


### PR DESCRIPTION
Ok I have been testing this change in production for a day, with several jobs being built on swarm slaves. All seems ok now.
