### PR TITLE
Add the tunnel option to pass it to the Jenkins engine

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -29,6 +29,11 @@ public class Options {
     @Option(name = "-master", usage = "The complete target Jenkins URL like 'http://server:8080/jenkins/'. If this option is specified, auto-discovery will be skipped")
     public String master;
 
+    @Option(name = "-tunnel", usage = "Connect to the specified host and port, instead of connecting directly to Jenkins. " +
+                    "Useful when connection to Hudson needs to be tunneled. Can be also HOST: or :PORT, " +
+                    "in which case the missing portion will be auto-configured like the default behavior")
+    public String tunnel;
+
     @Option(name = "-noRetryAfterConnected", usage = "Do not retry if a successful connection gets closed.")
     public boolean noRetryAfterConnected;
 

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -207,6 +207,14 @@ public class SwarmClient {
 
             args.add("-url");
             args.add(target.url);
+
+            // if the tunnel option is set in the command line, use it
+            if (options.tunnel != null) {
+                args.add("-tunnel");
+                args.add(options.tunnel);
+                System.out.println("Using tunnel through " + options.tunnel);
+            }
+
             if (options.username != null && options.password != null) {
                 args.add("-credentials");
                 args.add(options.username + ":" + options.password);


### PR DESCRIPTION
In some cases the jnlp port is not in the same host or port, due to load balancers, firewalls, etc. In my case I need it to run master and slaves in Kubernetes
