### PR TITLE
[FIXED JENKINS-26558] Clients should provide a unique ID to be used for ...

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -77,7 +77,7 @@ public class Client {
                     swarmClient.verifyThatUrlIsHudson(target);
                 }
 
-                System.out.println("Attempting to connect to " + target.url + " " + target.secret);
+                System.out.println("Attempting to connect to " + target.url + " " + target.secret + " with ID " + swarmClient.getHash());
 
                 // create a new swarm slave
                 swarmClient.createSwarmSlave(target);

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -2,6 +2,7 @@ package hudson.plugins.swarm;
 
 import hudson.remoting.Launcher;
 import hudson.remoting.jnlp.Main;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
@@ -439,23 +440,9 @@ public class SwarmClient {
         } catch (SocketException e) {
             // oh well we tried
         }
-        return getDigestOf(buf.toString()).substring(0, 8);
+        return DigestUtils.md5Hex(buf.toString()).substring(0, 8);
     }
 
-    public static String getDigestOf(String text) {
-        try {
-            return toHexString(MessageDigest.getInstance("MD5").digest(text.getBytes("UTF-8")));
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("MD5 not installed", e);    // impossible according to JLS
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException("UTF-8 not supported", e);    // impossible according to JLS
-        }
-    }
-
-    public static String toHexString(byte[] bytes) {
-        return String.format("%0" + (bytes.length * 2) + "x", new BigInteger(1, bytes));
-    }
-    
     private static class DefaultTrustManager implements X509TrustManager {
 
         public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -58,10 +58,13 @@ public class SwarmClient {
     private final Options options;
     
     private final String hash;
+    
+    private String name;
 
     public SwarmClient(Options options) {
         this.options = options;
         this.hash = hash(options.remoteFsRoot);
+        this.name = options.name;
     }
 
     public String getHash() {
@@ -203,7 +206,7 @@ public class SwarmClient {
         try {
             Launcher launcher = new Launcher();
 
-            launcher.slaveJnlpURL = new URL(target.url + "computer/" + options.name
+            launcher.slaveJnlpURL = new URL(target.url + "computer/" + name
                     + "/slave-agent.jnlp");
 
             if (options.username != null && options.password != null) {
@@ -322,13 +325,14 @@ public class SwarmClient {
         }
         String name = post.getResponseBodyAsString();
         if (name == null) {
+            this.name = options.name;
             return;
         }
         name = name.trim();
         if (name.isEmpty()) {
             return;
         }
-        options.name = name;
+        this.name = name;
     }
 
     private String encode(String value) throws UnsupportedEncodingException {

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -32,6 +32,7 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.HttpURLConnection;
 import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.NetworkInterface;
@@ -414,6 +415,8 @@ public class SwarmClient {
             for (NetworkInterface ni : Collections.list(NetworkInterface.getNetworkInterfaces())) {
                 for (InetAddress ia : Collections.list(ni.getInetAddresses())) {
                     if (ia instanceof Inet4Address) {
+                        buf.append(ia.getHostAddress()).append('\n');
+                    } else if (ia instanceof Inet6Address) {
                         buf.append(ia.getHostAddress()).append('\n');
                     }
                 }

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -322,8 +322,8 @@ public class SwarmClient {
 
         int responseCode = client.executeMethod(post);
         if (responseCode != 200) {
-            throw new RetryException(
-                    "Failed to create a slave on Jenkins CODE: " + responseCode);
+            throw new RetryException(String.format("Failed to create a slave on Jenkins CODE: %s%n%s",responseCode, 
+                    post.getResponseBodyAsString()) );
         }
         Properties props = new Properties();
         InputStream stream = post.getResponseBodyAsStream();

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -52,6 +52,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Properties;
 import java.util.Random;
 
 public class SwarmClient {
@@ -324,13 +325,23 @@ public class SwarmClient {
             throw new RetryException(
                     "Failed to create a slave on Jenkins CODE: " + responseCode);
         }
-        String name = post.getResponseBodyAsString();
+        Properties props = new Properties();
+        InputStream stream = post.getResponseBodyAsStream();
+        if (stream != null) {
+            try {
+                props.load(stream);
+            } finally {
+                stream.close();
+            }
+        }
+        String name = props.getProperty("name");
         if (name == null) {
             this.name = options.name;
             return;
         }
         name = name.trim();
         if (name.isEmpty()) {
+            this.name = options.name;
             return;
         }
         this.name = name;

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -53,6 +53,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.Random;
 
@@ -310,7 +311,7 @@ public class SwarmClient {
                 + param("labels", labelStr)
                 + param("toolLocations", toolLocationsStr)
                 + "&secret=" + target.secret
-                + param("mode", options.mode.toUpperCase())
+                + param("mode", options.mode.toUpperCase(Locale.ENGLISH))
                 + param("hash", hash)
         );
 

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -3,6 +3,7 @@ package hudson.plugins.swarm;
 import com.google.common.collect.Lists;
 import hudson.Plugin;
 import hudson.Util;
+import hudson.model.Computer;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Node;
 import hudson.slaves.SlaveComputer;
@@ -69,10 +70,14 @@ public class PluginImpl extends Plugin {
             // check for existing connections
             {
                 Node n = jenkins.getNode(name);
-                if (n != null && n.toComputer().isOnline()) {
-                    // this is an existing connection, we'll only cause issues if we trample over an online connection
-                    rsp.setStatus(SC_CONFLICT);
-                    return;
+                if (n != null) {
+                    Computer c = n.toComputer();
+                    if (c != null && c.isOnline()) {
+                        // this is an existing connection, we'll only cause issues if we trample over an online connection
+                        
+                        rsp.setStatus(SC_CONFLICT);
+                        return;
+                    }
                 }
             }
 

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -100,7 +100,7 @@ public class PluginImpl extends Plugin {
                 }
                 jenkins.addNode(slave);
             }
-            rsp.setContentType("text/plain; UTF-8");
+            rsp.setContentType("text/plain; charset=iso-8859-1");
             Properties props = new Properties();
             props.put("name", name);
             ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
...name collision avoidance

- The current name collision avoidance uses the requests address, which could very likely be the same for all clients
  as they could be being routed through a HTTP proxy (or two) so that is not a good disambiguator
- We use a digest of the client's interfaces and MAC addresses and the remoteFSRoot to try and give a consistent ID
- We ALWAYS append the ID if we have it as otherwise during reconnect the slaves with the same name will shuffle around
  which defeats a lot of the login that Jenkins has internally based on slaves having a consistent name
- In the event of legacy clients that do not have the ID we will let them connect with their name as long as there
  is no online slave with that name. This does mean that where there are multiple legacy swarm clients with the
  same name, only one can be on-line at any moment in time, but that is an improvement on the current where
  once a shuffle starts, none can stay on-line

@reviewbybees