### PR TITLE
[JENKINS-28148] Whitespaces in toolLocations

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -1,10 +1,12 @@
 package hudson.plugins.swarm;
 
 import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.MapOptionHandler;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -55,8 +57,12 @@ public class Options {
     )
     public String mode = ModeOptionHandler.NORMAL;
     
-    @Option(name = "-toolLocations", usage = "Whitespace-separated list of tool locations to be defined on this slave. A tool location is specified as 'toolName:location'")
-    public List<String> toolLocations = new ArrayList<String>();
+    @Option(
+            name = "-t", aliases = "--toolLocation",
+            usage = "A tool location to be defined on this slave. It is specified as 'toolName=location'", 
+            handler = MapOptionHandler.class
+    )
+    public Map<String,String> toolLocations;
 
     @Option(name = "-username", usage = "The Jenkins username for authentication")
     public String username;

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -15,7 +15,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.Text;
 import org.xml.sax.SAXException;
-
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -54,6 +53,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Random;
 
@@ -305,7 +305,10 @@ public class SwarmClient {
         // but immediately a 403 (Forbidden)
 
         String labelStr = StringUtils.join(options.labels, ' ');
-        String toolLocationsStr = StringUtils.join(options.toolLocations, ' ');
+        StringBuilder toolLocationBuilder = new StringBuilder();
+        for (Entry<String, String> toolLocation : options.toolLocations.entrySet()){
+            toolLocationBuilder.append(param("toolLocation",toolLocation.getKey()+":"+toolLocation.getValue()));
+        }
 
         PostMethod post = new PostMethod(target.url
                 + "/plugin/swarm/createSlave?name=" + options.name
@@ -313,7 +316,7 @@ public class SwarmClient {
                 + param("remoteFsRoot", options.remoteFsRoot.getAbsolutePath())
                 + param("description", options.description)
                 + param("labels", labelStr)
-                + param("toolLocations", toolLocationsStr)
+                + toolLocationBuilder.toString()
                 + "&secret=" + target.secret
                 + param("mode", options.mode.toUpperCase(Locale.ENGLISH))
                 + param("hash", hash)

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -12,7 +12,7 @@ import hudson.tools.ToolInstallation;
 import hudson.tools.ToolLocationNodeProperty;
 import hudson.tools.ToolLocationNodeProperty.ToolLocation;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -41,7 +41,7 @@ public class PluginImpl extends Plugin {
      */
     public void doCreateSlave(StaplerRequest req, StaplerResponse rsp, @QueryParameter String name, @QueryParameter String description, @QueryParameter int executors,
             @QueryParameter String remoteFsRoot, @QueryParameter String labels, @QueryParameter String secret, @QueryParameter Node.Mode mode, 
-            @QueryParameter String toolLocations, @QueryParameter(fixEmpty = true) String hash) throws IOException {
+            @QueryParameter(fixEmpty = true) String hash) throws IOException {
 
         if (!getSwarmSecret().equals(secret)) {
             rsp.setStatus(SC_FORBIDDEN);
@@ -53,8 +53,9 @@ public class PluginImpl extends Plugin {
 
             jenkins.checkPermission(SlaveComputer.CREATE);
             
+            String[] toolLocations = req.getParameterValues("toolLocation");
             List<ToolLocationNodeProperty> nodeProperties = Lists.newArrayList();
-            if (StringUtils.isNotBlank(toolLocations)) {
+            if (!ArrayUtils.isEmpty(toolLocations)) {
             	List<ToolLocation> parsedToolLocations = parseToolLocations(toolLocations);
 				nodeProperties = Lists.newArrayList(new ToolLocationNodeProperty(parsedToolLocations));
             }
@@ -115,11 +116,10 @@ public class PluginImpl extends Plugin {
         }
     }
 
-	private List<ToolLocation> parseToolLocations(String toolLocations) {
+	private List<ToolLocation> parseToolLocations(String[] toolLocations) {
 		List<ToolLocationNodeProperty.ToolLocation> result = Lists.newArrayList();
 		
-		String[] toolLocsArray = toolLocations.split(" ");
-		for (String toolLocKeyValue : toolLocsArray) {
+		for (String toolLocKeyValue : toolLocations) {
 			boolean found = false;
 			// Limit the split on only the first occurence
 			// of ':', so that the tool location path can


### PR DESCRIPTION
Use multiple values for toolLocations parameter instead of only one
with all tools, and splitting it by whitespace.
It allows to include whitespace in tool paths (cf windows)
Link to ticket: [JENKINS-28148](https://issues.jenkins-ci.org/browse/JENKINS-28148)

:warning: It is a breaking change !

The API of the CLI would now be :
```bash
-toolLocation tool1:location -toolLocation tool2:"a location"
```

Another options would be to change the separator of toolLocations. The semi-colon seems to be the best option for this. Leading to :
```bash
-toolLocations tool1:location;tool2:"a location"
```

Note that I tried to find some OptionHandler that would fit best, StringArrayOptionHandler for instance.
```bash
-toolLocations tool1:location "tool2:a location"
```
But it does not consider an option with quotes to be only one. Like current behaviour...

There is also the MapOptionHandler that would best fit the need IMO, but also requires to change the CLI API.
```bash
-toolLocation tool1=location -toolLocation tool2="a location"
```

I have implemented ~~the first one~~ the last one (see below) in this change.
Let me know which way do you prefer.