### PR TITLE
Set the HTTP Connection:close header to ensure the underlying socket …

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -186,8 +186,9 @@ public class SwarmClient {
         String url = masterURL.toExternalForm() + "plugin/swarm/slaveInfo";
         GetMethod get = new GetMethod(url);
         get.setDoAuthentication(true);
-        int responseCode = client.executeMethod(get);
+        get.addRequestHeader("Connection", "close");
 
+        int responseCode = client.executeMethod(get);
         if (responseCode != 200) {
             throw new RetryException(
                     "Failed to fetch slave info from Jenkins CODE: " + responseCode);
@@ -320,6 +321,7 @@ public class SwarmClient {
         );
 
         post.setDoAuthentication(true);
+        post.addRequestHeader("Connection", "close");
 
         Crumb csrfCrumb = getCsrfCrumb(client, target);
         if (csrfCrumb != null) {


### PR DESCRIPTION
…is closed. This addresses JENKINS-29232, where sockets remain in CLOSE_WAIT after master discovery is complete.