### PR TITLE
Improve end user reporting of hostname lookup errors

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -60,7 +60,11 @@ public class Client {
 	if (options.name == null) {
 	    try {
 		client.options.name = InetAddress.getLocalHost().getCanonicalHostName();
-	    } catch (UnknownHostException | IOException e) {
+	    } catch (UnknownHostException e) {
+		System.out.println("Failed to lookup the canonical hostname of this slave, please check system settings.");
+		System.out.println("If not possible to resolve please specify a node name using the '-name' option");
+		System.exit(-1);
+	    } catch (IOException e) {
 		System.out.println("Failed to lookup the canonical hostname of this slave, please check system settings.");
 		System.out.println("If not possible to resolve please specify a node name using the '-name' option");
 		System.exit(-1);

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -2,6 +2,7 @@ package hudson.plugins.swarm;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -16,7 +17,7 @@ import org.kohsuke.args4j.CmdLineParser;
  * joins it.
  *
  * @author Kohsuke Kawaguchi
- * @changes Marcelo Brunken, Dmitry Buzdin
+ * @changes Marcelo Brunken, Dmitry Buzdin, Peter Joensson
  */
 public class Client {
 
@@ -43,12 +44,34 @@ public class Client {
         if (options.passwordEnvVariable != null) {
             options.password = System.getenv(options.passwordEnvVariable);
         }
-        client.run();
+
+	// Only look up the hostname if we have not already specified
+	// name of the slave. Also in certain cases this lookup might fail.
+	// E.g.
+	// Querying a external DNS server which might not be informed
+	// of a newly created slave from a DHCP server.
+	//
+	// From https://docs.oracle.com/javase/8/docs/api/java/net/InetAddress.html#getCanonicalHostName--
+	//
+	// "Gets the fully qualified domain name for this IP
+	// address. Best effort method, meaning we may not be able to
+	// return the FQDN depending on the underlying system
+	// configuration."
+	if (options.name == null) {
+	    try {
+		client.options.name = InetAddress.getLocalHost().getCanonicalHostName();
+	    } catch (UnknownHostException | IOException e) {
+		System.out.println("Failed to lookup the canonical hostname of this slave, please check system settings.");
+		System.out.println("If not possible to resolve please specify a node name using the '-name' option");
+		System.exit(-1);
+	    }
+	}
+
+	client.run();
     }
 
-    public Client(Options options) throws IOException {
+    public Client(Options options) {
         this.options = options;
-        this.options.name = InetAddress.getLocalHost().getCanonicalHostName();
     }
 
     /**


### PR DESCRIPTION
The CanonicalHostName() method call is only best effors as stated in the
Java documentation:

   "Gets the fully qualified domain name for this IP address. Best effort
   method, meaning we may not be able to return the FQDN depending on
   the underlying system configuration"

This means that we can experience failures if the system configuration
is such that when the swarm client is launched we can't determine our
hostname. Since swarm slaves are often spawned in public/private clouds
there might be some eventual consistency with regards to lookup of
hostnames. We try to help the situation by printing a somewhat
informative error message.

Using the '-name' command line option for this should have been a way to
work around this. However we where unconditionally performing this
lookup. Instead we now only perform the lookup of no name has been
provided on the command line.

Thanks to @jacob-keller who reported this.