### PR TITLE
Updating jenkins remoting dependency

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
           <groupId>org.jenkins-ci.main</groupId>
           <artifactId>remoting</artifactId>
-          <version>2.52</version>
+          <version>2.53.2</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Swarm client now matches the jenkins-remoting version in Jenkins-1.625.3
LTS