### PR TITLE
Using getResponseBodyAsStream instead getResponseBody is recommended

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -197,7 +197,7 @@ public class SwarmClient {
 
         Document xml;
         try {
-            xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new ByteArrayInputStream(get.getResponseBody()));
+            xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(get.getResponseBodyAsStream());
         } catch (SAXException e) {
             throw new RetryException("Invalid XML received from " + url);
         }


### PR DESCRIPTION
To fix warnings like this:
```
Apr 09, 2016 9:05:41 PM org.apache.commons.httpclient.HttpMethodBase getResponseBody
WARNING: Going to buffer response body of large or unknown size. Using getResponseBodyAsStream instead is recommended.
```