### PR TITLE
Changes to the swarm client

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Candidate.java
+++ b/client/src/main/java/hudson/plugins/swarm/Candidate.java
@@ -1,5 +1,7 @@
 package hudson.plugins.swarm;
 
+import java.util.logging.*;
+
 /**
  *
  */
@@ -8,10 +10,13 @@ public class Candidate {
     final String url;
 
     final String secret;
+    private static final Logger logger =  Logger.getLogger(Candidate.class.getPackage().getName());
 
-    Candidate(String url, String secret) {
+    public Candidate(String url, String secret) {
         this.url = url;
         this.secret = secret;
+    
+        logger.fine("Candidate constructed with url: " + url + ", " + "secret: " + secret);
     }
 
 }

--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -1,0 +1,88 @@
+package hudson.plugins.swarm;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.lang.InterruptedException;
+import java.net.URISyntaxException;
+import java.lang.System;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class LabelFileWatcher implements Runnable {
+
+    private static String sFileName;
+    private static boolean bRunning = false;
+    private static String sLabels;
+    private static String[] sArgs;
+    
+    public LabelFileWatcher(String fName, String... args) throws IOException {
+        sFileName = fName;
+        sLabels = new String(Files.readAllBytes(Paths.get(sFileName)));
+        sArgs = args;
+    }
+
+    public void run() {
+        String sTempLabels;
+        bRunning = true;
+        System.out.println("LabelFileWatcher running, monitoring file: " + sFileName);
+        
+        
+        while(bRunning) {
+            try {
+                Thread.currentThread().sleep(10 * 1000);
+            }
+            catch(InterruptedException e) {
+                System.out.println("LabelFileWatcher InterruptedException occurred.");
+            }
+            try {
+                sTempLabels = new String(Files.readAllBytes(Paths.get(sFileName)));
+                if(!sTempLabels.equalsIgnoreCase(sLabels)) {
+                    System.out.println("NOTICE: " + sFileName + " has changed.  Slave restart initiated.");
+                    bRunning = false;
+                    final String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+                    try
+                    {
+                        final File currentJar = new File(LabelFileWatcher.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+                        if(!currentJar.getName().endsWith(".jar")) {
+                            System.out.println("ERROR: LabelFileWatcher unable to determine current running jar.  Slave failure.");
+                        }
+                        else {
+                            // invoke the restart
+                            final ArrayList<String> command = new ArrayList<String>();
+                            command.add(javaBin);
+                            command.add("-jar");
+                            command.add(currentJar.getPath());
+                            for(int i=0;i<sArgs.length;i++) {
+                                command.add(sArgs[i]);
+                            }
+                            String sCommandString = Arrays.toString(command.toArray());
+                            sCommandString = sCommandString.replaceAll("\n","").replaceAll("\r","").replaceAll(",","");
+                            System.out.println("Invoking: " + sCommandString);
+                            final ProcessBuilder builder = new ProcessBuilder(command);
+                            Process p = builder.start();
+                            System.out.println("New slave instance started.");
+                        }
+                    }
+                    catch(URISyntaxException e) {
+                        System.out.println("WARNING: LabelFileWatcher unable to determine current running jar.  Slave failure.  URISyntaxException.");
+                    }
+                }
+            }
+            catch(IOException e) {
+                System.out.println("WARNING: unable to read " + sFileName + ", slave may not be reporting proper labels to master.");
+            }
+        }
+        
+        System.out.println("LabelFileWatcher no longer running.  Shutting down this instance of Swarm Client.");
+        System.exit(0);
+    }
+    
+    public void stopLabelFileWatcher() {
+        bRunning = false;
+    }
+
+}

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -84,5 +84,11 @@ public class Options {
     
     @Option(name = "-candidateTag", usage = "Show swarm candidate with tag only")
     public String candidateTag;
-
+    
+    @Option(name = "-labelsFile", usage="File location with space delimited list of labels.  If the file changes, restarts this client.")
+    public String labelsFile;
+    
+    @Option(name = "-logFile", usage="File to write STDOUT and STDERR to. (Deprecated, use -Djava.util.logging.config.file={path}logging.properties instead)")
+    public String logFile;
+    
 }

--- a/client/src/main/java/hudson/plugins/swarm/logging.properties
+++ b/client/src/main/java/hudson/plugins/swarm/logging.properties
@@ -1,0 +1,61 @@
+############################################################
+#  	Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.  
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+
+# example launch of Swarm Client with labelsFile and logging
+#
+# java -Djava.util.logging.config.file=./logging.properties -jar swarm-client-jar-with-dependencies.jar -master http://10.211.55.12:8080 -labelsFile ~/labels.txt 
+
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+# handlers= java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+#.level= INFO
+.level= ALL
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/swarmclient%u.log
+java.util.logging.FileHandler.limit = 1000000
+java.util.logging.FileHandler.count = 99
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to INFO and above.
+java.util.logging.ConsoleHandler.level = CONFIG
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s %5$s%6$s%n
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# For example, set the com.xyz.foo logger to only log SEVERE
+# messages:
+


### PR DESCRIPTION
I added two options to the swarm client.  -logFile and -labelsFile.  -logFile is just a redirection of STDOUT and STDERR, as the swarm client used System.out.println().

-labelsFile adds a new capability to the swarm client.  If given a -labelsFile, the swarm client will read this file to find additional labels (besides the ones specified with the -labels option).  However, and more importantly, if the contents of the labels file change while the swarm client is running, the swarm client will restart itself so that the jenkins master will be updated with new labels.  In this way you may create a process whereby you install software on a slave node, update the labels file, and dynamically report the new capabilities to the jenkins master.

The second commit, I decided to fix the logging in the swarm client so that it now supports java.util.logging.*.  I also added a sample logging.properties file.  I'm not positive that the logging levels are what the original authors would have intended (since it was all System.out.println), but I tried to make educated guesses.  I marked -logFile as deprecated and added handling for that (it tells the user to use -Djava.util.logging.config.file instead).
