### PR TITLE
Upgrade remoting API to 2.62

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
           <groupId>org.jenkins-ci.main</groupId>
           <artifactId>remoting</artifactId>
-          <version>2.59</version>
+          <version>2.62</version>
         </dependency>
         <dependency>
             <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Version 2.62 contains a fix for the following bugs:
- https://issues.jenkins-ci.org/browse/JENKINS-22853
- https://issues.jenkins-ci.org/browse/JENKINS-23271 (possibly)

This occurs mostly with Java 8.

The remoting version matches with Jenkins 2.18/2.19/2.19.1/2.19.2.

Also it would be nice if you could trigger the release 2.3 following the merge of this pull request as to help deploy this.

Thanks!