### PR TITLE
Convert docker-compose file to version 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,16 @@
-swarm:
-  build: .
-  environment:
-    JENKINS_MASTER: 'jenkins'
-  links:
-   - jenkins
-jenkins:
-  build: jenkins/
-  ports:
-     - "8080:8080"
-     - "50000:50000"
-     - "36088:36088"
+version: '2'
+services:
+    swarm:
+        build: .
+        environment:
+            JENKINS_MASTER: 'jenkins'
+        depends_on:
+            - jenkins
+
+    jenkins:
+        build: jenkins/
+        ports:
+            - "8080:8080"
+            - "50000:50000"
+            - "36088:36088"
+            

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -12,9 +12,10 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
 
 RUN apt-get update && apt-get install wget curl netcat -y
 
-RUN wget -q -O - http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key | sudo apt-key add -
+RUN wget -q -O - http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key | apt-key add -
 RUN echo "deb http://pkg.jenkins-ci.org/debian-stable binary/" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install jenkins -y
+
 
 ENTRYPOINT ["su",  "-l",  "jenkins",  "-c",  "java -jar /usr/share/jenkins/jenkins.war"]


### PR DESCRIPTION
`link` is no longer necessary
`depends_on` tells docker-compose to start `jenkins` before the swarm