### PR TITLE
Add option -sslFingerprints

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -59,10 +59,11 @@ public class LabelFileWatcher implements Runnable {
     private HttpClient createHttpClient(URL urlForAuth) {
         logger.fine("createHttpClient() invoked");
 
-        if (opts.disableSslVerification) {
+        if (opts.disableSslVerification || !opts.sslFingerprints.isEmpty()) {
             try {
                 SSLContext ctx = SSLContext.getInstance("TLS");
-                ctx.init(new KeyManager[0], new TrustManager[]{new SwarmClient.DefaultTrustManager()}, new SecureRandom());
+                String trusted = opts.disableSslVerification ? "" : opts.sslFingerprints;
+                ctx.init(new KeyManager[0], new TrustManager[]{new SwarmClient.DefaultTrustManager(trusted)}, new SecureRandom());
                 SSLContext.setDefault(ctx);
             }
             catch (KeyManagementException e) {

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -62,6 +62,12 @@ public class Options {
     @Option(name = "-disableSslVerification", usage = "Disables SSL verification in the HttpClient.")
     public boolean disableSslVerification;
 
+    @Option(name = "-sslFingerprints", usage = "Whitespace-separated list of accepted certificate fingerprints (SHA-256/Hex), "+
+                                               "otherwise system truststore will be used. " +
+                                               "No revocation, expiration or not yet valid check will be performed " +
+                                               "for custom fingerprints! Multiple options are allowed.")
+    public String sslFingerprints;
+
     @Option(name = "-disableClientsUniqueId", usage = "Disables Clients unique ID.")
     public boolean disableClientsUniqueId;
 


### PR DESCRIPTION
Provide a possibility to add custom ssl trust anchors
for the user without adding own certificates to system-ca.
This is a lot easier if the swarm node is spawned in a
stateless (docker) container.