### PR TITLE
Bump remoting to latest version

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.4.1</version>
+        <version>3.7</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Any chance the remoting library could be bumped to latest? Among other things, the `3.4.1` release doesn't work correctly with Jenkins behind some proxies because of the way it compares HTTP headers.