### PR TITLE
JENKINS-42098 - Linkage error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ release.properties
 # IntelliJ project files 
 *.iml
 .idea/
+
+# eclipse project file
+.project
+.settings/
+.classpath

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -44,6 +44,18 @@
                     </excludes>
                   </filter>
                 </filters>
+                <relocations>
+                  <!-- Be ware! there is org.xxx class in the fwk, do not relocate them! -->
+                  <!-- hudson remoting seems to check some class also, so cannot be shaded -->
+                  <relocation>
+                    <pattern>org.apache</pattern>
+                    <shadedPattern>shaded.org.apache</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>org.slf4j</pattern>
+                    <shadedPattern>shaded.org.slf4j</shadedPattern>
+                  </relocation>
+                </relocations>
                 <transformers>
                   <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                     <manifestEntries>


### PR DESCRIPTION
If swarm plugin start a slave, some process mix up class from jenkins and from the client jar.

The shade plugin accept an option to relocate some class. Doing that, class cannot be mixup anymore.