### PR TITLE
Prevent infinite retry in hudson.remoting.Launcher.parseJnlpArguments()

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -264,6 +264,9 @@ public class SwarmClient {
         logger.fine("connect() invoked");
 
         Launcher launcher = new Launcher();
+        // prevent infinite retry in hudson.remoting.Launcher.parseJnlpArguments()
+        launcher.noReconnect = true;
+
         List<String> jnlpArgs = Collections.emptyList();
 
         try {


### PR DESCRIPTION
Sometimes when restarting the jenkins master the swarm-client gets stuck in an infinite retry loop in hudson.remoting.Launcher.parseJnlpArguments().

The error looks like this:
```
Failing to obtain http://jenkins:8080/computer/slave1/slave-agent.jnlp
java.io.IOException: Failed to load http://jenkins:8080/computer/slave1/slave-agent.jnlp: 404 Not Found
	at hudson.remoting.Launcher.parseJnlpArguments(Launcher.java:399)
	at hudson.plugins.swarm.SwarmClient.connect(SwarmClient.java:284)
	at hudson.plugins.swarm.Client.run(Client.java:135)
	at hudson.plugins.swarm.Client.main(Client.java:87)
Waiting 10 seconds before retry
Failing to obtain http://jenkins:8080/computer/slave1/slave-agent.jnlp
java.io.IOException: Failed to load http://jenkins:8080/computer/slave1/slave-agent.jnlp: 404 Not Found
	at hudson.remoting.Launcher.parseJnlpArguments(Launcher.java:399)
	at hudson.plugins.swarm.SwarmClient.connect(SwarmClient.java:284)
	at hudson.plugins.swarm.Client.run(Client.java:135)
	at hudson.plugins.swarm.Client.main(Client.java:87)
Waiting 10 seconds before retry
...
(Log from swarm-client-3.5)
```

Setting launcher.noReconnect makes Launcher throw an IOException that gets handled by the swarm-plugin retry mechanism.