### PR TITLE
Add ability to download the client directory from the plugin installed in Jenkins

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -19,6 +19,37 @@
         </developer>
     </developers>
 
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.0.2</version>
+          <executions>
+            <execution>
+              <id>copy</id>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>copy</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <artifactItems>
+              <artifactItem>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>swarm-client</artifactId>
+                <version>${project.version}</version>
+                <type>jar</type>
+                <overWrite>true</overWrite>
+                <outputDirectory>${project.build.directory}/${project.artifactId}</outputDirectory>
+                <destFileName>swarm-client.jar</destFileName>
+              </artifactItem>
+            </artifactItems>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/plugin/src/main/java/hudson/plugins/swarm/DownloadClientAction.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/DownloadClientAction.java
@@ -5,6 +5,8 @@ import hudson.model.UnprotectedRootAction;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
@@ -24,6 +26,7 @@ public class DownloadClientAction implements UnprotectedRootAction {
     }
 
     // serve static resources
+    @Restricted(NoExternalUse.class)
     public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         Jenkins.getActiveInstance().getPlugin("swarm").doDynamic(req, rsp);
     }

--- a/plugin/src/main/java/hudson/plugins/swarm/DownloadClientAction.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/DownloadClientAction.java
@@ -1,0 +1,30 @@
+package hudson.plugins.swarm;
+
+import hudson.Extension;
+import hudson.model.UnprotectedRootAction;
+import jenkins.model.Jenkins;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+
+@Extension
+public class DownloadClientAction implements UnprotectedRootAction {
+    public String getIconFileName() {
+        return null;
+    }
+
+    public String getDisplayName() {
+        return null;
+    }
+
+    public String getUrlName() {
+        return "swarm";
+    }
+
+    // serve static resources
+    public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+        Jenkins.getActiveInstance().getPlugin("swarm").doDynamic(req, rsp);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
     </licenses>
 
     <modules>
-        <module>plugin</module>
         <module>client</module>
+        <module>plugin</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
Add ability to download the client directory from the plugin with the URL http://jenkins_server:port/swarm/swarm-client.jar. This will simplify the availability and distribution of the client (especially in an enterprise context) and permit the creation of very simple, generic Docker containers for Jenkins slaves that would just download the client from Jenkins, making sure it is always up-to-date with Jenkins (in short, no more need to build a client container for every release of the client).