### PR TITLE
Update Swarm Plugin to Remoting 3.16

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.15</version>
+        <version>3.16</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Just a routine upgrade, it should not change anything for Swarm Client though the blacklist will be extended on the client receiver side.

Changelog: https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#316

@reviewbybees 
