### PR TITLE
Add a passwordFile option

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -5,6 +5,8 @@ import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
 import javax.xml.parsers.ParserConfigurationException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -84,6 +86,11 @@ public class Client {
         if (options.passwordEnvVariable != null) {
             options.password = System.getenv(options.passwordEnvVariable);
         }
+        // read pass from file if no other password was specified
+        if (options.password == null && options.passwordFile != null) {
+            options.password = new String(Files.readAllBytes(Paths.get(options.passwordFile)), "UTF-8");
+        }
+
 
         // Only look up the hostname if we have not already specified
         // name of the slave. Also in certain cases this lookup might fail.

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -102,6 +102,9 @@ public class Options {
     @Option(name = "-passwordEnvVariable", usage = "Environment variable that the password is stored in")
     public String passwordEnvVariable;
 
+    @Option(name = "-passwordFile", usage = "File containing the Jenkins user password")
+    public String passwordFile;
+
     @Option(name = "-showHostName", aliases = "--showHostName", usage = "Show hostnames instead of IP address")
     public boolean showHostName;
 


### PR DESCRIPTION
Jenkins displays the command line as well as environment variables in
the node's "systemInfo" page. This makes both of the current password
options very readily available in the jenkins UI.