### PR TITLE
Reduce log level from ALL to INFO in logging.properties

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/logging.properties
+++ b/client/src/main/java/hudson/plugins/swarm/logging.properties
@@ -32,8 +32,7 @@ handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 # can be overriden by a facility specific level
 # Note that the ConsoleHandler also has a separate level
 # setting to limit messages printed to the console.
-#.level= INFO
-.level= ALL
+.level= INFO
 
 ############################################################
 # Handler specific properties.


### PR DESCRIPTION
Log Level ALL led to a vast amount of log messages while Clone Workspace SCM Plugin was Archiving a workspace. This caused 100% CPU load severely degrading performance of this post-build step.

See https://issues.jenkins-ci.org/browse/JENKINS-49292