### PR TITLE
[JENKINS-50252] - Update Remoting in Swarm Client from 3.16 to 3.18

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.16</version>
+        <version>3.18</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-50252

The recent changes in serialization (JEP-200, JENKINS-49994) require diagnosability improvements and blacklist hardening. It's better to have them on both master and agent sides. There are also other diagnosability improvements like JENKINS-49415 which could be adopted.

@reviewbybees @jglick 
