### PR TITLE
Update Swarm Client to Remoting to 3.21

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.19</version>
+        <version>3.21</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
### Problem

The version of Remoting in Swarm Client is out-of-date.

### Solution

Update Remoting to the latest version.

### Implementation

I modeled this change after #69 and #70.

### Testing

- I ran `mvn package install` to ensure the build and unit tests didn't regress.
- I also realized that there don't seem to be any tests of the Swarm Client that actually run Jenkins, so I manually tested `swarm-client.jar` by invoking it against my production Jenkins master. I then successfully ran a simple pipeline job on that node.