### PR TITLE
Modernize POM files

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -1,38 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <!--FIXME: It uses Jenkins Plugin POM, but it should not. It appears to work, but it needs to be fixed ASAP.
-            The client cannot be built with 2.36, JAR packaging does not work there (and it should not)
-         -->
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>swarm-plugin</artifactId>
-        <version>3.13-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <groupId>org.jenkins-ci</groupId>
+        <artifactId>jenkins</artifactId>
+        <version>1.46</version>
+        <relativePath />
     </parent>
 
     <artifactId>swarm-client</artifactId>
+    <groupId>org.jenkins-ci.plugins</groupId>
     <packaging>jar</packaging>
     <name>Jenkins Swarm Plugin Client</name>
+    <version>3.13-SNAPSHOT</version>
 
     <properties>
       <java.level>8</java.level>
     </properties>
 
     <build>
+      <finalName>${project.artifactId}</finalName>
       <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <executions>
-            <execution>
-              <phase>none</phase>
-            </execution>
-          </executions>
-        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.1</version>
           <executions>
             <execution>
               <phase>package</phase>
@@ -84,7 +76,7 @@
       <dependency>
         <groupId>args4j</groupId>
         <artifactId>args4j</artifactId>
-        <version>2.0.29</version>
+        <version>2.0.31</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
@@ -105,7 +97,7 @@
       <dependency>
         <groupId>commons-httpclient</groupId>
         <artifactId>commons-httpclient</artifactId>
-        <version>3.1-jenkins-1</version>
+        <version>3.1</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -115,7 +107,7 @@
       <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
-        <version>2.4</version>
+        <version>2.6</version>
       </dependency>
       <dependency>
           <groupId>com.google.code.findbugs</groupId>
@@ -128,6 +120,12 @@
           <artifactId>jsr305</artifactId>
           <version>3.0.1</version>
           <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
       </dependency>
     </dependencies>
 </project>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -24,7 +25,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.0.2</version>
+          <version>3.1.1</version>
           <executions>
             <execution>
               <id>copy</id>

--- a/plugin/src/main/java/hudson/plugins/swarm/DownloadClientAction.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/DownloadClientAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.swarm;
 
 import hudson.Extension;
+import hudson.Plugin;
 import hudson.model.UnprotectedRootAction;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerRequest;
@@ -28,6 +29,9 @@ public class DownloadClientAction implements UnprotectedRootAction {
     // serve static resources
     @Restricted(NoExternalUse.class)
     public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
-        Jenkins.getActiveInstance().getPlugin("swarm").doDynamic(req, rsp);
+        Plugin plugin = Jenkins.getActiveInstance().getPlugin("swarm");
+        if (plugin != null) {
+            plugin.doDynamic(req, rsp);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <!--TODO: Update once the client code is cleaned UP -->
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
+        <version>3.14</version>
+        <relativePath />
     </parent>
 
     <artifactId>swarm-plugin</artifactId>
@@ -12,10 +13,15 @@
     <name>Jenkins Self-Organizing Swarm Plug-in</name>
     <version>3.13-SNAPSHOT</version>
 
+    <properties>
+        <jenkins.version>2.60.1</jenkins.version>
+        <java.level>8</java.level>
+    </properties>
+
     <licenses>
         <license>
-            <name>MIT license</name>
-            <comments>All source code is under the MIT license.</comments>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
 
@@ -25,10 +31,9 @@
     </modules>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/swarm-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/swarm-plugin.git</developerConnection>
-        <url>http://github.com/jenkinsci/swarm-plugin</url>
-        <tag>swarm-plugin-3.2</tag>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}</url>
     </scm>
 
     <repositories>
@@ -37,42 +42,6 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
-
-    <!-- hopefully these entries aren't needed when we bump up to more recent Jenkins -->
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.cloudbees</groupId>
-                <artifactId>maven-license-plugin</artifactId>
-                <version>1.4</version>
-            </plugin>
-            <plugin>
-                <groupId>org.kohsuke</groupId>
-                <artifactId>access-modifier-checker</artifactId>
-                <version>1.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-        </plugins>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.scm</groupId>
-                            <artifactId>maven-scm-provider-gitexe</artifactId>
-                            <version>1.9</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>


### PR DESCRIPTION
### Problem

The Maven build infrastructure for the Swarm Client uses the [Jenkins Plugin Parent POM](https://github.com/jenkinsci/plugin-pom), but it should not. Per the comments: "It appears to work, but it needs to be fixed ASAP. The client cannot be built with 2.36, JAR packaging does not work there (and it should not)." Additionally, the parent POM and Maven plugins used in the build are out-of-date, as are some of the dependencies.

### Solution

Update the Swarm Client to use the [Jenkins Parent POM](https://github.com/jenkinsci/pom) instead of the [Jenkins Plugin Parent POM](https://github.com/jenkinsci/plugin-pom). Update all parent POMs and Maven plugins to the latest versions as well. Bump the Jenkins core version to the first LTS release that supports Java 8, and update the dependencies to match this release.

### Implementation

- After changing the Swarm Client to use the Jenkins Parent POM, I found that the `groupId` had changed. To preserve existing semantics, I explicitly set it back to the original `groupId` of `org.jenkins-ci.plugins`. I also found that the version of the parent POM was being used as the version of the Swarm Client, which was incorrect. To preserve existing semantics, I set the version to `3.13-SNAPSHOT`. With that, the JAR started building, but I found that the plugin expected it to be named `swarm-client.jar` rather than `swarm-client-3.13-SNAPSHOT.jar`. To preserve the old name, I set `finalName` to `${project.artifactId}`. While I was here, I removed the `findbugs-maven-plugin` configuration so that it could be inherited from the Jenkins Parent POM. I also updated the Maven Shade Plugin to the latest version and bumped `args4j`, `commons-httpclient`, and `commons-lang` to the versions used by Jenkins 2.60.1 LTS. Finally, I had to add JUnit to the test scope to get the tests to compile.
- I updated the plugin to the latest Jenkins Plugin POM and also updated the Maven Dependency Plugin to the latest version. This exposed a NPE via FindBugs, which I wrapped in a null check. I saw a comment near the build plugins section of the POM that said: "Hopefully these entries aren't needed when we bump up to more recent Jenkins". I deleted them, and things seem to work fine. Finally, I tidied up the `licenses` and `scm` sections to match the latest POM archetype.

### Testing

- `mvn package` passes.
- I manually inspected the contents of `swarm-client.jar` to make sure the shaded dependencies were still present. The `.class` files in the JAR were identical to a JAR built before these changes, modulo the expected version bumps of a few third-party dependencies.
- I manually installed the `swarm.hpi` from these changes on a staging Jenkins instance. Then I started my usual production jobs that use the Swarm Client (using a `swarm-client.jar` built with these changes). The jobs ran without issues, including successfully resuming after a Jenkins restart.