### PR TITLE
Update remoting version from 3.21 to 3.26

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.21</version>
+        <version>3.26</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
Basically same as https://github.com/jenkinsci/remoting-kafka-plugin/pull/43
