### PR TITLE
Update remoting version from 3.26 to 3.27

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>remoting</artifactId>
-        <version>3.26</version>
+        <version>3.27</version>
       </dependency>
       <dependency>
         <groupId>commons-httpclient</groupId>


### PR DESCRIPTION
### Problem
The version of Remoting in Swarm Client is out-of-date, swarm agents reporting 3.26 version of remoting

### Solution
Update Remoting to the latest version.

### Implementation
Just did the same as #70.

### Testing
Not executed testing, except Jenkins CI