### PR TITLE
Simplify node replacement code

### DIFF
--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -202,14 +202,7 @@ public class PluginImpl extends Plugin {
             SwarmSlave slave = new SwarmSlave(name, "Swarm slave from " + req.getRemoteHost() + " : " + description,
                     remoteFsRoot, String.valueOf(executors), mode, "swarm " + Util.fixNull(labels), nodeProperties);
 
-            // if this still results in a duplicate, so be it
-            synchronized (jenkins) {
-                Node n = jenkins.getNode(name);
-                if (n != null) {
-                    jenkins.removeNode(n);
-                }
-                jenkins.addNode(slave);
-            }
+            jenkins.addNode(slave);
             rsp.setContentType("text/plain; charset=iso-8859-1");
             Properties props = new Properties();
             props.put("name", name);


### PR DESCRIPTION
Downstream of jenkinsci/swarm-plugin#83. As @jglick observed in jenkinsci/workflow-durable-task-step-plugin#104, [the existing code](https://github.com/jenkinsci/swarm-plugin/blob/796a04914e986f0fe6ab720e2cc95169831251dc/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java#L213-L220) looks wrong. It could all be replaced by simply

```java
jenkins.addNode(slave);
```

since that method already replaces any existing node of the same name, without firing the deleted event.