### PR TITLE
Use a fixed port when running integration tests that restart Jenkins

### DIFF
--- a/plugin/src/test/java/hudson/plugins/swarm/PipelineJobTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/PipelineJobTest.java
@@ -24,7 +24,9 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 public class PipelineJobTest {
 
-    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+    @Rule
+    public RestartableJenkinsRule story =
+            new RestartableJenkinsRule.Builder().withReusedPort().build();
 
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
 
@@ -157,9 +159,6 @@ public class PipelineJobTest {
      */
     @Test
     public void buildShellScriptAfterRestart() {
-        Assume.assumeNotNull(
-                System.getProperty("port"), "This test requires a fixed port to be available.");
-
         story.then(
                 s -> {
                     // "-deleteExistingClients" is needed so that the Swarm Client can connect

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43</version>
+        <version>3.46</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Downstream of jenkinsci/swarm-plugin#81 and jenkinsci/jenkins-test-harness#132.