### PR TITLE
Prevent XML External Entity (XXE) attacks

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -111,7 +111,9 @@ public class LabelFileWatcher implements Runnable {
 
         Document xml;
         try {
-            xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(new ByteArrayInputStream(
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            xml = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(
                     get.getResponseBody()));
         } catch (Exception e) {
             String msg = "Invalid XML received from " + targ.getURL();

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -110,7 +110,9 @@ public class SwarmClient {
             String address = printable(recv.getAddress());
 
             try {
-                xml = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(
+                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+                dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                xml = dbf.newDocumentBuilder().parse(
                         new ByteArrayInputStream(recv.getData(), 0, recv.getLength()));
             } catch (SAXException e) {
                 logger.severe("Invalid response XML from " + address + ": " + responseXml);


### PR DESCRIPTION
Disable DTDs (External Entities) completely in all XML parsers as recommended in the OWASP Foundation's [XML External Entity Prevention Cheat Sheet](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.md). This should resolve SECURITY-1252/CVE-2019-10309.