### PR TITLE
Make this final field labelFileWatcherThread static

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -29,7 +29,7 @@ public class Client {
     private static final Logger logger = Logger.getLogger(Client.class.getPackage().getName());
 
     private final Options options;
-    private static final Thread labelFileWatcherThread = null;
+    //private static final Thread labelFileWatcherThread = null;
 
     //TODO: Cleanup the encoding issue
     public static void main(String... args) throws InterruptedException, IOException {
@@ -146,7 +146,7 @@ public class Client {
                 }
 
                 // set up label file watcher thread (if the label file changes, this thread takes action to restart the client)
-                if (options.labelsFile != null && labelFileWatcherThread == null) {
+                if (options.labelsFile != null) {
                     logger.info("Setting up LabelFileWatcher");
                     LabelFileWatcher l = new LabelFileWatcher(target, options, args);
                     Thread labelFileWatcherThread = new Thread(l, "LabelFileWatcher");

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -29,7 +29,7 @@ public class Client {
     private static final Logger logger = Logger.getLogger(Client.class.getPackage().getName());
 
     private final Options options;
-    private final Thread labelFileWatcherThread = null;
+    private static final Thread labelFileWatcherThread = null;
 
     //TODO: Cleanup the encoding issue
     public static void main(String... args) throws InterruptedException, IOException {

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -29,7 +29,6 @@ public class Client {
     private static final Logger logger = Logger.getLogger(Client.class.getPackage().getName());
 
     private final Options options;
-    //private static final Thread labelFileWatcherThread = null;
 
     //TODO: Cleanup the encoding issue
     public static void main(String... args) throws InterruptedException, IOException {


### PR DESCRIPTION
Making a public constant just final as opposed to static final leads to duplicating its value for every instance of the class, uselessly increasing the amount of memory required to execute the application.
[https://rules.sonarsource.com/java/type/Code%20Smell/RSPEC-1170](url)