### PR TITLE
Reorder the modifiers

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -29,7 +29,7 @@ public class Client {
     private static final Logger logger = Logger.getLogger(Client.class.getPackage().getName());
 
     private final Options options;
-    private static final Thread labelFileWatcherThread = null;
+    //private static final Thread labelFileWatcherThread = null;
 
     //TODO: Cleanup the encoding issue
     public static void main(String... args) throws InterruptedException, IOException {
@@ -146,7 +146,7 @@ public class Client {
                 }
 
                 // set up label file watcher thread (if the label file changes, this thread takes action to restart the client)
-                if (options.labelsFile != null && labelFileWatcherThread == null) {
+                if (options.labelsFile != null) {
                     logger.info("Setting up LabelFileWatcher");
                     LabelFileWatcher l = new LabelFileWatcher(target, options, args);
                     Thread labelFileWatcherThread = new Thread(l, "LabelFileWatcher");

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -29,7 +29,7 @@ public class Client {
     private static final Logger logger = Logger.getLogger(Client.class.getPackage().getName());
 
     private final Options options;
-    private final Thread labelFileWatcherThread = null;
+    private static final Thread labelFileWatcherThread = null;
 
     //TODO: Cleanup the encoding issue
     public static void main(String... args) throws InterruptedException, IOException {

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -29,7 +29,6 @@ public class Client {
     private static final Logger logger = Logger.getLogger(Client.class.getPackage().getName());
 
     private final Options options;
-    //private static final Thread labelFileWatcherThread = null;
 
     //TODO: Cleanup the encoding issue
     public static void main(String... args) throws InterruptedException, IOException {

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -310,7 +310,7 @@ public class SwarmClient {
         }
     }
 
-    public synchronized static HttpClient getGlobalHttpClient() {
+    public static synchronized HttpClient getGlobalHttpClient() {
         if (g_client == null) {
             g_client = new HttpClient(new MultiThreadedHttpConnectionManager());
         }
@@ -349,7 +349,7 @@ public class SwarmClient {
         return client;
     }
 
-    protected synchronized static Crumb getCsrfCrumb(HttpClient client, Candidate target) throws IOException {
+    protected static synchronized Crumb getCsrfCrumb(HttpClient client, Candidate target) throws IOException {
         logger.finer("getCsrfCrumb() invoked");
 
         GetMethod httpGet = null;
@@ -477,7 +477,7 @@ public class SwarmClient {
         }
     }
 
-    protected synchronized static void postLabelRemove(String name, String labels, HttpClient client, Candidate target) throws IOException, RetryException {
+    protected static synchronized void postLabelRemove(String name, String labels, HttpClient client, Candidate target) throws IOException, RetryException {
         PostMethod post = null;
 
         try {
@@ -509,7 +509,7 @@ public class SwarmClient {
         }
     }
 
-    protected synchronized static void postLabelAppend(String name, String labels, HttpClient client, Candidate target) throws RetryException, IOException {
+    protected static synchronized void postLabelAppend(String name, String labels, HttpClient client, Candidate target) throws RetryException, IOException {
         PostMethod post = null;
 
         try {
@@ -541,13 +541,13 @@ public class SwarmClient {
         }
     }
 
-    private synchronized static String encode(String value) throws UnsupportedEncodingException {
+    private static synchronized String encode(String value) throws UnsupportedEncodingException {
         logger.finer("encode() invoked");
 
         return URLEncoder.encode(value, "UTF-8");
     }
 
-    protected synchronized static String param(String name, String value) throws UnsupportedEncodingException {
+    protected static synchronized String param(String name, String value) throws UnsupportedEncodingException {
         logger.finer("param() invoked");
 
         if (value == null) {


### PR DESCRIPTION
@calphool 
i found several Code Smells and fixed them.
The Java Language Specification recommends listing modifiers in the following order:

1. Annotations

2. public

3. protected

4. private

5. abstract

6. static

7. final

8. transient

9. volatile

10. synchronized

11. native

12. strictfp

Not following this convention has no technical impact, but will reduce the code's readability because most developers are used to the standard order.

see [https://rules.sonarsource.com/java/RSPEC-1124](url)