### PR TITLE
POM updates

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -24,6 +24,12 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <build>
       <finalName>${project.artifactId}</finalName>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -15,6 +15,10 @@
 
     <developers>
         <developer>
+            <id>basil</id>
+            <name>Basil Crow</name>
+        </developer>
+        <developer>
             <id>kohsuke</id>
             <name>Kohsuke Kawaguchi</name>
         </developer>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>3.16-SNAPSHOT</version>
 
     <properties>
-        <jenkins.version>2.60.1</jenkins.version>
+        <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.37</version>
+        <version>3.43</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
- Update plugin parent POM to [latest version](https://github.com/jenkinsci/plugin-pom/releases)
- Update developer list
- Add `<pluginRepositories>` section to client POM as recommended in [archetype](https://github.com/jenkinsci/archetypes/blob/09f4e2bd6b6b59794279d7c96af37004beceb17d/empty-plugin/src/main/resources/archetype-resources/pom.xml#L39-L43)
- Bump Jenkins version to [latest 2.60 LTS release](https://jenkins.io/changelog-stable/)