### PR TITLE
Strengthen XXE checks

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -135,6 +135,11 @@
           <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>org.kohsuke</groupId>
+        <artifactId>access-modifier-annotation</artifactId>
+        <version>1.16</version>
+      </dependency>
+      <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
           <version>4.12</version>

--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -111,10 +111,7 @@ public class LabelFileWatcher implements Runnable {
 
         Document xml;
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            xml = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(
-                    get.getResponseBody()));
+            xml = XmlUtils.parse(get.getResponseBody());
         } catch (Exception e) {
             String msg = "Invalid XML received from " + targ.getURL();
             logger.log(Level.SEVERE, msg, e);

--- a/client/src/main/java/hudson/plugins/swarm/RestrictiveEntityResolver.java
+++ b/client/src/main/java/hudson/plugins/swarm/RestrictiveEntityResolver.java
@@ -1,0 +1,35 @@
+package hudson.plugins.swarm;
+
+import java.io.IOException;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * An EntityResolver that will fail to resolve any entities. Useful in preventing External XML
+ * Entity injection attacks.
+ */
+@Restricted(NoExternalUse.class)
+public final class RestrictiveEntityResolver implements EntityResolver {
+
+    public static final RestrictiveEntityResolver INSTANCE = new RestrictiveEntityResolver();
+
+    private RestrictiveEntityResolver() {
+        // prevent multiple instantiation.
+        super();
+    }
+
+    /** Throws a SAXException if this tried to resolve any entity. */
+    @Override
+    public InputSource resolveEntity(String publicId, String systemId)
+            throws SAXException, IOException {
+        throw new SAXException(
+                "Refusing to resolve entity with publicId("
+                        + publicId
+                        + ") and systemId ("
+                        + systemId
+                        + ")");
+    }
+}

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -110,10 +110,7 @@ public class SwarmClient {
             String address = printable(recv.getAddress());
 
             try {
-                DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-                dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-                xml = dbf.newDocumentBuilder().parse(
-                        new ByteArrayInputStream(recv.getData(), 0, recv.getLength()));
+                xml = XmlUtils.parse(recv.getData());
             } catch (SAXException e) {
                 logger.severe("Invalid response XML from " + address + ": " + responseXml);
                 continue;

--- a/client/src/main/java/hudson/plugins/swarm/XmlUtils.java
+++ b/client/src/main/java/hudson/plugins/swarm/XmlUtils.java
@@ -1,0 +1,103 @@
+package hudson.plugins.swarm;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+@Restricted(NoExternalUse.class)
+public final class XmlUtils {
+
+    private static final Logger LOGGER =
+            LogManager.getLogManager().getLogger(XmlUtils.class.getName());
+
+    /**
+     * Parse the supplied XML stream data to a {@link Document}.
+     *
+     * <p>This function does not close the stream.
+     *
+     * @param stream The XML stream.
+     * @return The XML {@link Document}.
+     * @throws SAXException Error parsing the XML stream data e.g. badly formed XML.
+     * @throws IOException Error reading from the steam.
+     */
+    private static @Nonnull Document parse(@Nonnull InputStream stream)
+            throws IOException, SAXException {
+        DocumentBuilder docBuilder;
+
+        try {
+            docBuilder = newDocumentBuilderFactory().newDocumentBuilder();
+            docBuilder.setEntityResolver(RestrictiveEntityResolver.INSTANCE);
+        } catch (ParserConfigurationException e) {
+            throw new IllegalStateException("Unexpected error creating DocumentBuilder.", e);
+        }
+
+        return docBuilder.parse(stream);
+    }
+
+    /**
+     * Parse the supplied XML file data to a {@link Document}.
+     *
+     * @param buf The input buffer.
+     * @return The parsed document.
+     * @throws SAXException Error parsing the XML file data e.g. badly formed XML.
+     * @throws IOException Error reading from the file.
+     */
+    public static @Nonnull Document parse(@Nonnull byte[] buf) throws SAXException, IOException {
+        try (InputStream inputStream = new ByteArrayInputStream(buf)) {
+            return parse(inputStream);
+        }
+    }
+
+    private static DocumentBuilderFactory newDocumentBuilderFactory() {
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        // Set parser features to prevent against XXE etc.
+        // Note: setting only the external entity features on DocumentBuilderFactory instance
+        // (ala how safeTransform does it for SAXTransformerFactory) does seem to work (was still
+        // processing the entities - tried Oracle JDK 7 and 8 on OSX). Setting seems a bit extreme,
+        // but looks like there's no other choice.
+        documentBuilderFactory.setXIncludeAware(false);
+        documentBuilderFactory.setExpandEntityReferences(false);
+        setDocumentBuilderFactoryFeature(
+                documentBuilderFactory, XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        setDocumentBuilderFactoryFeature(
+                documentBuilderFactory,
+                "http://xml.org/sax/features/external-general-entities",
+                false);
+        setDocumentBuilderFactoryFeature(
+                documentBuilderFactory,
+                "http://xml.org/sax/features/external-parameter-entities",
+                false);
+        setDocumentBuilderFactoryFeature(
+                documentBuilderFactory,
+                "http://apache.org/xml/features/disallow-doctype-decl",
+                true);
+
+        return documentBuilderFactory;
+    }
+
+    private static void setDocumentBuilderFactoryFeature(
+            DocumentBuilderFactory documentBuilderFactory, String feature, boolean state) {
+        try {
+            documentBuilderFactory.setFeature(feature, state);
+        } catch (Exception e) {
+            LOGGER.log(
+                    Level.WARNING,
+                    String.format(
+                            "Failed to set the XML Document Builder factory feature %s to %s",
+                            feature, state),
+                    e);
+        }
+    }
+}


### PR DESCRIPTION
Per offline feedback from @daniel-beck, incorporate additional logic from [`jenkins.util.xml.XMLUtils`](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/util/xml/XMLUtils.java) and [jenkins.util.xml.RestrictiveEntityResolver](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/jenkins/util/xml/RestrictiveEntityResolver.java).

The `RestrictiveEntityResolver` class, as well as the `newDocumentBuilderFactory` and `setDocumentBuilderFactoryFeature` methods, were taken from upstream verbatim. The `parse` methods were adapted slightly from upstream to work with byte arrays rather than strings/files.