### PR TITLE
Fix that all swarm-client files are included in swarm.hpi

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -33,7 +33,7 @@
           <executions>
             <execution>
               <id>copy</id>
-              <phase>prepare-package</phase>
+              <phase>process-resources</phase>
               <goals>
                 <goal>copy</goal>
               </goals>
@@ -58,7 +58,7 @@
           <artifactId>maven-hpi-plugin</artifactId>
           <version>3.5</version>
           <configuration>
-            <warSourceDirectory>../client/target</warSourceDirectory>
+            <warSourceDirectory>${project.build.directory}/${project.artifactId}</warSourceDirectory>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
This issue has been introduced in commit c0e44ac605.

Copy the swarm-client.jar in an earlier phase to be available for tests too.
Only use the plugin/target/swarm directory as source for extra files, as it anyway contains all packaged files.