### PR TITLE
Fix incorrect GitHub URLs

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -14,6 +14,13 @@
     <name>Jenkins Swarm Plugin Client</name>
     <version>3.17-SNAPSHOT</version>
 
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/swarm-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/swarm-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/swarm-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <properties>
       <java.level>8</java.level>
       <project.build.outputEncoding>UTF-8</project.build.outputEncoding>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <!--
+        TODO: Set the parent of org.jenkins-ci.plugins:swarm (whose POM is
+        swarm-plugin/plugin/pom.xml) to org.jenkins-ci.plugins:plugin directly
+        rather than going through org.jenkins-ci.plugins:swarm-client (whose POM
+        is swarm-plugin/pom.xml).
+    -->
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>swarm-plugin</artifactId>
@@ -23,6 +29,13 @@
             <name>Kohsuke Kawaguchi</name>
         </developer>
     </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <build>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <!--
+        TODO: org.jenkins-ci.plugins:swarm-client (whose POM is
+        swarm-plugin/pom.xml) should not have any parent POM and should ideally
+        be as empty a shell as possible in order to support its two
+        sub-projects: org.jenkins-ci.plugins:swarm-client (whose POM is
+        swarm-plugin/client/pom.xml and whose parent is org.jenkins-ci:jenkins)
+        and org.jenkins-ci.plugins:swarm (whose POM is
+        swarm-plugin/plugin/pom.xml and whose parent should ideally be
+        org.jenkins-ci.plugins:plugin).
+    -->
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>


### PR DESCRIPTION
### Problem

When running `mvn help:effective-pom`, we see three projects:

1. `org.jenkins-ci.plugins:swarm-plugin:pom` (whose POM is [`swarm-plugin/pom.xml`](https://github.com/jenkinsci/swarm-plugin/blob/master/pom.xml))
2. `org.jenkins-ci.plugins:swarm-client:jar` (whose POM is [`swarm-plugin/client/pom.xml`](https://github.com/jenkinsci/swarm-plugin/blob/master/client/pom.xml))
3. `org.jenkins-ci.plugins:swarm:hpi` (whose POM is [`swarm-plugin/plugin/pom.xml`](https://github.com/jenkinsci/swarm-plugin/blob/master/plugin/pom.xml))

Setting aside for now the general messiness of this build, the GitHub URLs for these effective POMs are as follows:

1. `org.jenkins-ci.plugins:swarm-plugin:pom`: https://github.com/jenkinsci/swarm-plugin (correct)
2. `org.jenkins-ci.plugins:swarm-client:jar`: https://github.com/jenkinsci/pom/swarm-client (incorrect)
3. `org.jenkins-ci.plugins:swarm:hpi`: https://github.com/jenkinsci/swarm/swarm (incorrect)

The fact that the GitHub URL for `org.jenkins-ci.plugins:swarm:hpi` is incorrect means that the GitHub link on [the Jenkins plugins site](https://plugins.jenkins.io/swarm) is wrong.

### Evaluation

This build system is a mess. The parent POM of `org.jenkins-ci.plugins:swarm-client:pom` is currently [the Jenkins plugin POM](https://github.com/jenkinsci/plugin-pom), which makes no sense since `org.jenkins-ci.plugins:swarm-client:pom` is the parent project of both the Swarm plugin (where the Jenkins plugin POM is relevant) and the Swarm client (where the Jenkins plugin POM is irrelevant).

### Ideal Solution

Ideally, we'd set the parent of `org.jenkins-ci.plugins:swarm:hpi` to [the Jenkins plugin POM](https://github.com/jenkinsci/plugin-pom) directly rather than going through `org.jenkins-ci.plugins:swarm-client:pom`, which shouldn't have the Jenkins plugin POM as its parent since it is the parent project for both the Swarm plugin and the Swarm client. The Swarm client already uses [the main Jenkins POM](https://github.com/jenkinsci/pom) as its parent and would need no changes.

### Temporary Workaround

I'm new to Maven and don't have the time at present to tackle this larger change. I might tackle this in a subsequent release. I'd also welcome any contributions from people who are more familiar with Maven multi-project builds. I've left `TODO` comments explaining what I think needs to be done.

In the meantime, I've overridden the incorrect URLs with the correct ones in `org.jenkins-ci.plugins:swarm-client:jar` and `org.jenkins-ci.plugins:swarm:hpi`. The latter should fix the bad URL on [the Jenkins plugins site](https://plugins.jenkins.io/swarm).

### Testing

Ran `mvn help:effective-pom` and compared the SCM URLs in each project before and after this change. Before this change, the URLs were incorrect in `org.jenkins-ci.plugins:swarm-client:jar` and `org.jenkins-ci.plugins:swarm:hpi`. After this change, the URLs were correct.