### PR TITLE
Rework logging of arguments

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -80,8 +80,6 @@ public class SwarmClient {
 
     @SuppressFBWarnings("DM_EXIT")
     public SwarmClient(Options options) {
-        logger.config("SwarmClient constructed with " + options);
-
         this.options = options;
         Map<String, String> env = System.getenv();
         if (env.containsKey("MESOS_TASK_ID") && StringUtils.isNotEmpty(env.get("MESOS_TASK_ID"))) {


### PR DESCRIPTION
### Problem

When the Swarm client is run with the `-password` parameter, the password is logged in plain text to the console / logfile.

```
$ java -jar swarm-client.jar -master http://localhost:8080 -username some_user -password some_password
[...]
May 27, 2019 9:16:20 PM hudson.plugins.swarm.Client main INFO: Client.main invoked with: [-master http://localhost:8080 -username some_user -password some_password]
```

The desired behavior is to mask the password.

### Solution

The general approach is to keep logging arguments but to mask the sensitive arguments.

I considered trying to change the existing logic that prints `String... args` to avoid printing `-username` and `-password` arguments. However, implementing that correctly amounts to writing a parser, and it doesn't make sense to write a parser when we are already parsing `args` later on. So I switched to a different approach; namely, printing the parsed arguments. This is a minor change in user-facing functionality, as we now print all (non-null) options rather than just the ones the user provided. However, I don't think users should mind seeing the additional information (if anything, it should help give clarity into the default values that are being used). The advantage of this approach is that it lets us use the robust parsing logic from `kohsuke/args4j` to identify the sensitive arguments and mask their values.

### Implementation

First, we deleted the existing code that logs `String... args`. The variable `s` (which is only created for logging purposes) also needs to be removed.

With that having been done, we wrote a new `logArguments` method. This needs to be called after the call to `CmdLineParser#parseArguments` so that the parser has a chance to parse all the arguments. The method iterates over all the parsed arguments and options and logs them. If the key is "-username" or "-password", we log a masked value instead. The result looks like this:

```
INFO: Swarm Client is running with the following configuration: -autoDiscoveryAddress 255.255.255.255 -deleteExistingClients false -disableClientsUniqueId false -disableSslVerification false -executors 8 -fsroot . -help (--help) false -labels [] -master http://localhost:8080/ -maxRetryInterval 60 -mode normal -noRetryAfterConnected false -password ***** -retry -1 -retryBackOffStrategy NONE -retryInterval 10 -showHostName (--showHostName) false -sslFingerprints  -t (--toolLocation) {toolName=location} -username ***** 
```

Note that the username and password have been masked with five asterisks.

Also note that the Swarm client uses the [`kohsuke/args4j`](https://github.com/kohsuke/args4j) library, which has a (basically undocumented) feature to load arguments from files when the value starts with `@`. We considered implementing a special case to not mask such "passwords" that are really just file paths, but we decided against it. The benefit of showing "passwords" that are just file paths is that we don't unnecessarily mask non-sensitive data. The drawback is that we would introduce an implicit dependency on an undocumented feature in another project. If we implemented a special case for values that start with `@` and then this `args4j` feature is removed (which is not inconceivable given that it is not part of any public API), then we would be failing to mask sensitive data. Given that the benefit is small but the risk is large, we decided to avoid the special case, thereby limiting the attack vector for any possible future issues.

### Testing

To test this change, I ran the Swarm Client with `FINEST` level logging. I connected and grepped for my password in standard out as well as the Swarm Client logs at `FINEST` level both before and after this change. Before this change, the password appeared in both log files as described in this report. After this change, the grep turned up no results.