### PR TITLE
Set platform encoding to ensure build is platform-independent

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -16,6 +16,9 @@
 
     <properties>
       <java.level>8</java.level>
+      <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <repositories>


### PR DESCRIPTION
### Problem

The build reports the following warnings:

```
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
```

### Solution

Set the encoding as done in the [plugin POM](https://github.com/jenkinsci/plugin-pom/blob/a1b9b3b84b4bbb4ac43a22164b37a8aa3d1c4966/pom.xml#L45-L47).