### PR TITLE
JENKINS-50970 SLF4J logging not working in Swarm client

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -19,6 +19,7 @@
       <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+      <slf4j.version>1.7.26</slf4j.version>
     </properties>
 
     <repositories>
@@ -40,7 +41,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.1</version>
           <executions>
             <execution>
               <phase>package</phase>
@@ -98,12 +99,17 @@
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.1.1</version>
-        <scope>provided</scope>
+        <scope>provided</scope><!-- by jcl-over-slf4j -->
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
-        <version>1.7.22</version>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-jdk14</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
### Problem

When the Swarm Client starts, the following message gets printed:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder"
SLF4J: Defaulting to no-operation (NOP) loger implementation
```

Note that this doesn't prevent `java.util.logging` logs from getting printed.

### Evaluation

Both Swarm and Remoting use `java.util.logging` and import neither SLF4J nor Jakarta Commons Logging (JCL), so I wondered SLF4J was in the picture at all here. I asked myself: should we remove SLF4J? Then I realized that we depend on `commons-httpclient`, which itself depends on JCL:

```
+- commons-httpclient:commons-httpclient:jar:3.1:compile
|  \- commons-logging:commons-logging:jar:1.0.4:compile
```

So SLF4J isn't completely useless; we can use it to bridge the log statements made by `commons-httpclient` to the `java.util.logging` stream already used by Swarm and Remoting. But right now SLF4J doesn't have any backend configured, hence the warning.

### Solution

Add an SLF4J backend. Of the many available choices, it made the most sense to use the `java.util.logging` backend. The vast majority of log statements are already made to `java.util.logging` directly by Swarm and Remoting. This change just adds the log statements made by `commons-httpclient` (through JCL) to this stream.

### Bonus

Bumped the version of `maven-shade-plugin` while I was here.

### Testing

Ran the Swarm client with a verbose `java.util.logging` configuration. Ensured that the error had disappeared and that JCL log statements from `commons-httpclient` were making it into the FINE level logs via SLF4J.