### PR TITLE
Document logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Swarm Plugin
+# Swarm
 
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/swarm-plugin/master)](https://ci.jenkins.io/job/Plugins/job/swarm-plugin/job/master/)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/swarm.svg)](https://plugins.jenkins.io/swarm)
@@ -12,3 +12,7 @@ leave the cluster.
 
 See [the Swarm Plugin page](https://wiki.jenkins.io/display/JENKINS/Swarm+Plugin)
 on the Jenkins wiki for more information.
+
+### Documentation
+
+* [Logging](docs/logging.md)

--- a/client/logging.properties
+++ b/client/logging.properties
@@ -1,0 +1,41 @@
+############################################################
+#      Default Logging Configuration File
+#
+# You can use a different file by specifying a filename
+# with the java.util.logging.config.file system property.
+# For example java -Djava.util.logging.config.file=myfile
+############################################################
+
+############################################################
+#      Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the CONFIG and above levels.
+handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level= ALL
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# default file output is in user's home directory.
+java.util.logging.FileHandler.pattern = %h/swarm-client.log
+java.util.logging.FileHandler.limit = 20000000
+java.util.logging.FileHandler.count = 5
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
+
+# Limit the message that are printed on the console to CONFIG and above.
+java.util.logging.ConsoleHandler.level = CONFIG
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,43 @@
+# Logging and Diagnostics
+
+## Standard logging
+
+[Jenkins uses `java.util.logging` for
+logging](https://wiki.jenkins.io/display/JENKINS/Logging), including in
+[Remoting](https://github.com/jenkinsci/remoting) and
+[Swarm](https://github.com/jenkinsci/swarm-plugin). By default,
+`java.util.logging` uses the configuration from
+`$JAVA_HOME/jre/lib/logging.properties`. This is typically something like the
+following:
+
+```
+handlers= java.util.logging.ConsoleHandler
+.level= INFO
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+```
+
+The default handler,
+[`ConsoleHandler`](https://docs.oracle.com/javase/8/docs/api/java/util/logging/ConsoleHandler.html),
+sends `INFO`-level log records to `System.err`, using
+[`SimpleFormatter`](https://docs.oracle.com/javase/8/docs/api/java/util/logging/SimpleFormatter.html).
+
+### Configuration
+
+To get more detailed logs from the Swarm client, create a custom
+`logging.properties` file and pass it in via the
+`java.util.logging.config.file` property. This repository contains [a sample
+verbose `logging.properties` file](../client/logging.properties). You can also
+customize the format of the logs by passing in the
+`java.util.logging.SimpleFormatter.format` property. For example:
+
+```
+java \
+	-Djava.util.logging.SimpleFormatter.format='%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s %5$s%6$s%n' \
+	-Djava.util.logging.config.file='logging.properties' \
+	-jar swarm-client.jar
+```
+
+For more information about the property file format, see the [Oracle
+documentation](https://docs.oracle.com/cd/E19717-01/819-7753/6n9m71435/index.html)
+and [this guide](http://tutorials.jenkov.com/java-logging/configuration.html).


### PR DESCRIPTION
While working on [https://issues.jenkins-ci.org/browse/JENKINS-50970](https://issues.jenkins-ci.org/browse/JENKINS-50970), I noticed that the user seemed confused about how to get more verbose logs in Swarm client. As a user, I myself was confused about this at one point in time. This change adds documentation to enable future users to set up verbose logging with a minimum amount of effort.