### PR TITLE
Fix invalid exit code

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -46,7 +46,7 @@ public class Client {
         } catch (CmdLineException e) {
             logger.log(Level.SEVERE, "CmdLineException occurred during parseArgument", e);
             p.printUsage(System.out);
-            System.exit(-1);
+            System.exit(1);
         }
 
         if (options.help) {
@@ -56,7 +56,7 @@ public class Client {
 
         if (options.logFile != null) {
             logger.severe("-logFile has been deprecated. Use logging properties file syntax instead: -Djava.util.logging.config.file=" + Paths.get("").toAbsolutePath().toString() + File.separator + "logging.properties");
-            System.exit(-1);
+            System.exit(1);
         }
 
         if (options.pidFile != null) {
@@ -72,7 +72,7 @@ public class Client {
                 Files.write(pidFile.toPath(), pid.getBytes(UTF_8));
             } catch (IOException exception) {
                 logger.severe("Failed writing PID file: " + options.pidFile);
-                System.exit(-1);
+                System.exit(1);
             }
         }
 
@@ -105,7 +105,7 @@ public class Client {
             } catch (IOException e) {
                 logger.severe("Failed to lookup the canonical hostname of this slave, please check system settings.");
                 logger.severe("If not possible to resolve please specify a node name using the '-name' option");
-                System.exit(-1);
+                System.exit(1);
             }
         }
 
@@ -180,7 +180,7 @@ public class Client {
             if (options.retry >= 0) {
                 if (retry >= options.retry) {
                     logger.severe("Retry limit reached, exiting...");
-                    swarmClient.exitWithStatus(-1);
+                    swarmClient.exitWithStatus(1);
                 } else {
                     logger.warning("Remaining retries: " + (options.retry - retry));
                 }

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -76,7 +76,7 @@ public class SwarmClient {
             } catch (IOException e) {
                 logger.log(Level.SEVERE, "Problem reading labels from file " + options.labelsFile, e);
                 e.printStackTrace();
-                System.exit(-1);
+                System.exit(1);
             }
         }
     }

--- a/client/src/test/java/hudson/plugins/swarm/ClientTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/ClientTest.java
@@ -17,10 +17,10 @@ public class ClientTest {
         Options options = givenBackOff(NONE);
         // one try
         options.retry = 1;
-        runAndVerify(options, "Exited with status -1 after 0 seconds");
+        runAndVerify(options, "Exited with status 1 after 0 seconds");
         // a few tries
         options.retry = 5;
-        runAndVerify(options, "Exited with status -1 after 40 seconds");
+        runAndVerify(options, "Exited with status 1 after 40 seconds");
     }
 
     @Test
@@ -33,19 +33,19 @@ public class ClientTest {
     @Test
     public void should_run_with_no_backoff() {
         Options options = givenBackOff(NONE);
-        runAndVerify(options, "Exited with status -1 after 90 seconds");
+        runAndVerify(options, "Exited with status 1 after 90 seconds");
     }
 
     @Test
     public void should_run_with_linear_backoff() {
         Options options = givenBackOff(LINEAR);
-        runAndVerify(options, "Exited with status -1 after 450 seconds");
+        runAndVerify(options, "Exited with status 1 after 450 seconds");
     }
 
     @Test
     public void should_run_with_exponential_backoff() {
         Options options = givenBackOff(EXPONENTIAL);
-        runAndVerify(options, "Exited with status -1 after 750 seconds");
+        runAndVerify(options, "Exited with status 1 after 750 seconds");
     }
 
     private Options givenBackOff(RetryBackOffStrategy retryBackOffStrategy) {


### PR DESCRIPTION
Only positive numbers are allowed.

The former -1 is out of range and therefore for example converted by Bash to 255.

For more details see:
- http://tldp.org/LDP/abs/html/exitcodes.html
- http://en.wikipedia.org/wiki/Exit_status