### PR TITLE
Migrate from Commons HttpClient 3.x to HttpComponents Client 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,5 @@ on the Jenkins wiki for more information.
 
 ### Documentation
 
+* [Proxy Configuration](docs/proxy.md)
 * [Logging](docs/logging.md)

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -98,7 +98,7 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.1.1</version>
+        <version>1.2</version>
         <scope>provided</scope><!-- by jcl-over-slf4j -->
       </dependency>
       <dependency>
@@ -117,14 +117,14 @@
         <version>3.30</version>
       </dependency>
       <dependency>
-        <groupId>commons-httpclient</groupId>
-        <artifactId>commons-httpclient</artifactId>
-        <version>3.1</version>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.8</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.9</version>
+        <version>1.11</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -11,7 +11,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.xml.parsers.ParserConfigurationException;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
@@ -159,9 +158,6 @@ public class Client {
                 }
             } catch (IOException e) {
                 logger.log(Level.SEVERE, "IOException occurred", e);
-                e.printStackTrace();
-            } catch (ParserConfigurationException e) {
-                logger.log(Level.SEVERE, "ParserConfigurationException occurred", e);
                 e.printStackTrace();
             } catch (RetryException e) {
                 logger.log(Level.SEVERE, "RetryException occurred", e);

--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -22,13 +22,23 @@ import java.util.logging.Logger;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.UsernamePasswordCredentials;
-import org.apache.commons.httpclient.auth.AuthScope;
-import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
 public class LabelFileWatcher implements Runnable {
 
@@ -51,7 +61,7 @@ public class LabelFileWatcher implements Runnable {
         logger.config("Labels loaded: " + sLabels);
     }
 
-    private HttpClient createHttpClient(URL urlForAuth) {
+    private CloseableHttpClient createHttpClient(URL urlForAuth) {
         logger.fine("createHttpClient() invoked");
 
         if (opts.disableSslVerification || !opts.sslFingerprints.isEmpty()) {
@@ -69,17 +79,32 @@ public class LabelFileWatcher implements Runnable {
             }
         }
 
-        HttpClient client = SwarmClient.getGlobalHttpClient();
+        return HttpClients.createSystem();
+    }
+
+    protected HttpClientContext createHttpClientContext(URL urlForAuth) {
+        logger.fine("createHttpClientContext() invoked");
+
+        HttpClientContext context = HttpClientContext.create();
 
         if (opts.username != null && opts.password != null) {
             logger.fine("Setting HttpClient credentials based on options passed");
-            client.getState().setCredentials(
+
+            CredentialsProvider credsProvider = new BasicCredentialsProvider();
+            credsProvider.setCredentials(
                     new AuthScope(urlForAuth.getHost(), urlForAuth.getPort()),
                     new UsernamePasswordCredentials(opts.username, opts.password));
+            context.setCredentialsProvider(credsProvider);
+
+            AuthCache authCache = new BasicAuthCache();
+            authCache.put(
+                    new HttpHost(
+                            urlForAuth.getHost(), urlForAuth.getPort(), urlForAuth.getProtocol()),
+                    new BasicScheme());
+            context.setAuthCache(authCache);
         }
 
-        client.getParams().setAuthenticationPreemptive(true);
-        return client;
+        return context;
     }
 
     private void softLabelUpdate(String sNewLabels) throws SoftLabelUpdateException, MalformedURLException {
@@ -87,26 +112,39 @@ public class LabelFileWatcher implements Runnable {
         // 2. issue remove command for all old labels
         // 3. issue update commands for new labels
         logger.log(Level.CONFIG, "NOTICE: " + sFileName + " has changed.  Attempting soft label update (no node restart)");
-        HttpClient h = createHttpClient(new URL(targ.getURL()));
+        URL urlForAuth = new URL(targ.getURL());
+        CloseableHttpClient h = createHttpClient(urlForAuth);
+        HttpClientContext context = createHttpClientContext(urlForAuth);
 
         logger.log(Level.CONFIG, "Getting current labels from master");
 
-        GetMethod get = new GetMethod(targ.getURL()
-                    + "/plugin/swarm/getSlaveLabels?name=" + opts.name
-                    + "&secret=" + targ.getSecret());
-        try {
-            int responseCode = h.executeMethod(get);
-            if (responseCode != HttpStatus.SC_OK) {
-                logger.log(Level.CONFIG, "Failed to retrieve labels from master -- Response code: " + responseCode);
-                throw new SoftLabelUpdateException("Unable to acquire labels from master to begin removal process.");
-            }
-        } catch (IOException ignored) {}
-
         Document xml;
-        try {
-            xml = XmlUtils.parse(get.getResponseBody());
-        } catch (Exception e) {
-            String msg = "Invalid XML received from " + targ.getURL();
+
+        HttpGet get =
+                new HttpGet(
+                        targ.getURL()
+                                + "/plugin/swarm/getSlaveLabels?name="
+                                + opts.name
+                                + "&secret="
+                                + targ.getSecret());
+        try (CloseableHttpResponse response = h.execute(get, context)) {
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                logger.log(
+                        Level.CONFIG,
+                        "Failed to retrieve labels from master -- Response code: "
+                                + response.getStatusLine().getStatusCode());
+                throw new SoftLabelUpdateException(
+                        "Unable to acquire labels from master to begin removal process.");
+            }
+            try {
+                xml = XmlUtils.parse(response.getEntity().getContent());
+            } catch (SAXException e) {
+                String msg = "Invalid XML received from " + targ.getURL();
+                logger.log(Level.SEVERE, msg, e);
+                throw new SoftLabelUpdateException(msg);
+            }
+        } catch (IOException e) {
+            String msg = "IOException when reading from " + targ.getURL();
             logger.log(Level.SEVERE, msg, e);
             throw new SoftLabelUpdateException(msg);
         }
@@ -124,15 +162,23 @@ public class LabelFileWatcher implements Runnable {
             sb.append(" ");
             if (sb.length() > 1000) {
                 try {
-                    SwarmClient.postLabelRemove(opts.name, sb.toString(), h, targ);
-                    sb = new StringBuilder();
-                } catch (Exception ignored) {}
+                    SwarmClient.postLabelRemove(opts.name, sb.toString(), h, context, targ);
+                } catch (IOException | RetryException e) {
+                    String msg = "Exception when removing label from " + targ.getURL();
+                    logger.log(Level.SEVERE, msg, e);
+                    throw new SoftLabelUpdateException(msg);
+                }
+                sb = new StringBuilder();
             }
         }
         if (sb.length() > 0) {
             try {
-                SwarmClient.postLabelRemove(opts.name, sb.toString(), h, targ);
-            } catch (Exception ignored) {}
+                SwarmClient.postLabelRemove(opts.name, sb.toString(), h, context, targ);
+            } catch (IOException | RetryException e) {
+                String msg = "Exception when removing label from " + targ.getURL();
+                logger.log(Level.SEVERE, msg, e);
+                throw new SoftLabelUpdateException(msg);
+            }
         }
 
         // now add the labels back on
@@ -144,19 +190,25 @@ public class LabelFileWatcher implements Runnable {
             sb.append(" ");
             if (sb.length() > 1000) {
                 try {
-                    SwarmClient.postLabelAppend(opts.name, sb.toString(), h, targ);
-                    sb = new StringBuilder();
-                } catch (Exception ignored) {}
+                    SwarmClient.postLabelAppend(opts.name, sb.toString(), h, context, targ);
+                } catch (IOException | RetryException e) {
+                    String msg = "Exception when appending label to " + targ.getURL();
+                    logger.log(Level.SEVERE, msg, e);
+                    throw new SoftLabelUpdateException(msg);
+                }
+                sb = new StringBuilder();
             }
         }
 
         if (sb.length() > 0) {
             try {
-                SwarmClient.postLabelAppend(opts.name, sb.toString(), h, targ);
-            } catch (Exception ignored) {}
+                SwarmClient.postLabelAppend(opts.name, sb.toString(), h, context, targ);
+            } catch (IOException | RetryException e) {
+                String msg = "Exception when appending label to " + targ.getURL();
+                logger.log(Level.SEVERE, msg, e);
+                throw new SoftLabelUpdateException(msg);
+            }
         }
-
-        get.releaseConnection();
     }
 
     private void hardLabelUpdate() throws IOException {

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -5,6 +5,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.remoting.Launcher;
 import hudson.remoting.jnlp.Main;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,16 +46,24 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
-import org.apache.commons.httpclient.UsernamePasswordCredentials;
-import org.apache.commons.httpclient.auth.AuthScope;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -68,8 +77,6 @@ public class SwarmClient {
     private final Options options;
     private final String hash;
     private String name;
-    private static HttpClient g_client = null;
-
 
     @SuppressFBWarnings("DM_EXIT")
     public SwarmClient(Options options) {
@@ -118,7 +125,7 @@ public class SwarmClient {
     }
 
     private Candidate getCandidateFromDatagramResponses(List<DatagramPacket> responses)
-            throws IOException, RetryException {
+            throws RetryException {
         logger.finer("getCandidateFromDatagramResponses() invoked");
 
         List<Candidate> candidates = new ArrayList<>();
@@ -129,9 +136,9 @@ public class SwarmClient {
 
             String address = printable(recv.getAddress());
 
-            try {
-                xml = XmlUtils.parse(recv.getData());
-            } catch (SAXException e) {
+            try (InputStream inputStream = new ByteArrayInputStream(recv.getData())) {
+                xml = XmlUtils.parse(inputStream);
+            } catch (IOException | SAXException e) {
                 logger.severe("Invalid response XML from " + address + ": " + responseXml);
                 continue;
             }
@@ -203,7 +210,7 @@ public class SwarmClient {
         }
     }
 
-    public Candidate discoverFromMasterUrl() throws IOException, ParserConfigurationException, RetryException {
+    public Candidate discoverFromMasterUrl() throws IOException, RetryException {
         logger.config("discoverFromMasterUrl() invoked");
 
         if (!options.master.endsWith("/")) {
@@ -219,25 +226,22 @@ public class SwarmClient {
         }
 
         logger.config("Connecting to " + masterURL + " to configure swarm client.");
-        HttpClient client = createHttpClient(masterURL);
+        CloseableHttpClient client = createHttpClient(masterURL);
+        HttpClientContext context = createHttpClientContext(masterURL);
 
-        GetMethod get = null;
         String swarmSecret;
 
-        try {
-            String url = masterURL.toExternalForm() + "plugin/swarm/slaveInfo";
-            get = new GetMethod(url);
-            get.setDoAuthentication(true);
-            get.addRequestHeader("Connection", "close");
-
-            int responseCode = client.executeMethod(get);
-            if (responseCode != 200) {
-                if (responseCode == 404) {
+        String url = masterURL.toExternalForm() + "plugin/swarm/slaveInfo";
+        HttpGet get = new HttpGet(url);
+        get.addHeader("Connection", "close");
+        try (CloseableHttpResponse response = client.execute(get, context)) {
+            if (response.getStatusLine().getStatusCode() != 200) {
+                if (response.getStatusLine().getStatusCode() == 404) {
                     String msg = "Failed to fetch swarm information from Jenkins, plugin not installed?";
                     logger.log(Level.SEVERE, msg);
                     throw new RetryException(msg);
                 } else {
-                    String msg = "Failed to fetch slave info from Jenkins, HTTP response code: " + responseCode;
+                    String msg = "Failed to fetch slave info from Jenkins, HTTP response code: " + response.getStatusLine().getStatusCode();
                     logger.log(Level.SEVERE, msg);
                     throw new RetryException(msg);
                 }
@@ -245,17 +249,13 @@ public class SwarmClient {
 
             Document xml;
             try {
-                xml = XmlUtils.parse(get.getResponseBody());
+                xml = XmlUtils.parse(response.getEntity().getContent());
             } catch (SAXException e) {
                 String msg = "Invalid XML received from " + url;
                 logger.log(Level.SEVERE, msg, e);
                 throw new RetryException(msg);
             }
             swarmSecret = getChildElementString(xml.getDocumentElement(), "swarmSecret");
-        } finally {
-            if (get != null) {
-                get.releaseConnection();
-            }
         }
 
         return new Candidate(masterURL.toExternalForm(), swarmSecret);
@@ -328,15 +328,7 @@ public class SwarmClient {
         }
     }
 
-    public static synchronized HttpClient getGlobalHttpClient() {
-        if (g_client == null) {
-            g_client = new HttpClient(new MultiThreadedHttpConnectionManager());
-        }
-
-        return g_client;
-    }
-
-    protected HttpClient createHttpClient(URL urlForAuth) {
+    protected CloseableHttpClient createHttpClient(URL urlForAuth) {
         logger.fine("createHttpClient() invoked");
 
         if (options.disableSslVerification || !options.sslFingerprints.isEmpty()) {
@@ -354,42 +346,61 @@ public class SwarmClient {
             }
         }
 
-        HttpClient client = getGlobalHttpClient();
+        return HttpClients.createSystem();
+    }
+
+    protected HttpClientContext createHttpClientContext(URL urlForAuth) {
+        logger.fine("createHttpClientContext() invoked");
+
+        HttpClientContext context = HttpClientContext.create();
 
         if (options.username != null && options.password != null) {
             logger.fine("Setting HttpClient credentials based on options passed");
-            client.getState().setCredentials(
+
+            CredentialsProvider credsProvider = new BasicCredentialsProvider();
+            credsProvider.setCredentials(
                     new AuthScope(urlForAuth.getHost(), urlForAuth.getPort()),
                     new UsernamePasswordCredentials(options.username, options.password));
+            context.setCredentialsProvider(credsProvider);
+
+            AuthCache authCache = new BasicAuthCache();
+            authCache.put(
+                    new HttpHost(
+                            urlForAuth.getHost(), urlForAuth.getPort(), urlForAuth.getProtocol()),
+                    new BasicScheme());
+            context.setAuthCache(authCache);
         }
 
-        client.getParams().setAuthenticationPreemptive(true);
-        return client;
+        return context;
     }
 
-    protected static synchronized Crumb getCsrfCrumb(HttpClient client, Candidate target) throws IOException {
+    protected static synchronized Crumb getCsrfCrumb(
+            CloseableHttpClient client, HttpClientContext context, Candidate target)
+            throws IOException {
         logger.finer("getCsrfCrumb() invoked");
 
-        GetMethod httpGet = null;
         String[] crumbResponse;
 
-        try {
-            httpGet = new GetMethod(target.url + "crumbIssuer/api/xml?xpath=" +
-                    URLEncoder.encode("concat(//crumbRequestField,\":\",//crumb)", "UTF-8"));
-            httpGet.setDoAuthentication(true);
-            int responseCode = client.executeMethod(httpGet);
-            if (responseCode != HttpStatus.SC_OK) {
-                logger.log(Level.SEVERE, "Could not obtain CSRF crumb. Response code: " + responseCode);
+        HttpGet httpGet =
+                new HttpGet(
+                        target.url
+                                + "crumbIssuer/api/xml?xpath="
+                                + URLEncoder.encode(
+                                        "concat(//crumbRequestField,\":\",//crumb)", "UTF-8"));
+        try (CloseableHttpResponse response = client.execute(httpGet, context)) {
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                logger.log(
+                        Level.SEVERE,
+                        "Could not obtain CSRF crumb. Response code: "
+                                + response.getStatusLine().getStatusCode());
                 return null;
             }
-            crumbResponse = httpGet.getResponseBodyAsString().split(":");
+
+            String crumbResponseString = EntityUtils.toString(response.getEntity(), UTF_8);
+            crumbResponse = crumbResponseString.split(":");
             if (crumbResponse.length != 2) {
-                logger.log(Level.SEVERE, "Unexpected CSRF crumb response: " + httpGet.getResponseBodyAsString());
+                logger.log(Level.SEVERE, "Unexpected CSRF crumb response: " + crumbResponseString);
                 return null;
-            }
-        } finally {
-            if (httpGet != null) {
-                httpGet.releaseConnection();
             }
         }
 
@@ -399,7 +410,9 @@ public class SwarmClient {
     protected void createSwarmSlave(Candidate target) throws IOException, RetryException {
         logger.fine("createSwarmSlave() invoked");
 
-        HttpClient client = createHttpClient(new URL(target.url));
+        URL urlForAuth = new URL(target.url);
+        CloseableHttpClient client = createHttpClient(urlForAuth);
+        HttpClientContext context = createHttpClientContext(urlForAuth);
 
         // Jenkins does not do any authentication negotiation,
         // ie. it does not return a 401 (Unauthorized)
@@ -418,50 +431,47 @@ public class SwarmClient {
             sMyLabels = "";
         }
 
-        PostMethod post = null;
         Properties props = new Properties();
 
-        try {
-            post = new PostMethod(target.url
-                    + "plugin/swarm/createSlave?name=" + options.name
-                    + "&executors=" + options.executors
-                    + param("remoteFsRoot", options.remoteFsRoot.getAbsolutePath())
-                    + param("description", options.description)
-                    + param("labels", sMyLabels)
-                    + toolLocationBuilder.toString()
-                    + "&secret=" + target.secret
-                    + param("mode", options.mode.toUpperCase(Locale.ENGLISH))
-                    + param("hash", hash)
-                    + param("deleteExistingClients", Boolean.toString(options.deleteExistingClients))
-            );
+        HttpPost post =
+                new HttpPost(
+                        target.url
+                                + "plugin/swarm/createSlave?name="
+                                + options.name
+                                + "&executors="
+                                + options.executors
+                                + param("remoteFsRoot", options.remoteFsRoot.getAbsolutePath())
+                                + param("description", options.description)
+                                + param("labels", sMyLabels)
+                                + toolLocationBuilder.toString()
+                                + "&secret="
+                                + target.secret
+                                + param("mode", options.mode.toUpperCase(Locale.ENGLISH))
+                                + param("hash", hash)
+                                + param(
+                                        "deleteExistingClients",
+                                        Boolean.toString(options.deleteExistingClients)));
 
-            post.setDoAuthentication(true);
-            post.addRequestHeader("Connection", "close");
+        post.addHeader("Connection", "close");
 
-            Crumb csrfCrumb = getCsrfCrumb(client, target);
-            if (csrfCrumb != null) {
-                post.addRequestHeader(csrfCrumb.crumbRequestField, csrfCrumb.crumb);
-            }
+        Crumb csrfCrumb = getCsrfCrumb(client, context, target);
+        if (csrfCrumb != null) {
+            post.addHeader(csrfCrumb.crumbRequestField, csrfCrumb.crumb);
+        }
 
-            int responseCode = client.executeMethod(post);
-            if (responseCode != HttpStatus.SC_OK) {
-                String msg = String.format("Failed to create a slave on Jenkins, response code: %s%n%s",
-                        responseCode,
-                        post.getResponseBodyAsString());
+        try (CloseableHttpResponse response = client.execute(post, context)) {
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                String msg =
+                        String.format(
+                                "Failed to create a slave on Jenkins, response code: %s%n%s",
+                                response.getStatusLine().getStatusCode(),
+                                EntityUtils.toString(response.getEntity(), UTF_8));
                 logger.log(Level.SEVERE, msg);
                 throw new RetryException(msg);
             }
-            InputStream stream = post.getResponseBodyAsStream();
-            if (stream != null) {
-                try {
-                    props.load(stream);
-                } finally {
-                    stream.close();
-                }
-            }
-        } finally {
-            if (post != null) {
-                post.releaseConnection();
+
+            try (InputStream stream = response.getEntity().getContent()) {
+                props.load(stream);
             }
         }
 
@@ -485,76 +495,84 @@ public class SwarmClient {
                 sb.append(s);
                 sb.append(" ");
                 if (sb.length() > 1000) {
-                    postLabelAppend(name, sb.toString(), client, target);
+                    postLabelAppend(name, sb.toString(), client, context, target);
                     sb = new StringBuilder();
                 }
             }
             if (sb.length() > 0) {
-                postLabelAppend(name, sb.toString(), client, target);
+                postLabelAppend(name, sb.toString(), client, context, target);
             }
         }
     }
 
-    protected static synchronized void postLabelRemove(String name, String labels, HttpClient client, Candidate target) throws IOException, RetryException {
-        PostMethod post = null;
+    protected static synchronized void postLabelRemove(
+            String name,
+            String labels,
+            CloseableHttpClient client,
+            HttpClientContext context,
+            Candidate target)
+            throws IOException, RetryException {
+        HttpPost post =
+                new HttpPost(
+                        target.url
+                                + "plugin/swarm/removeSlaveLabels?name="
+                                + name
+                                + "&secret="
+                                + target.secret
+                                + SwarmClient.param("labels", labels));
 
-        try {
-            post = new PostMethod(target.url
-                    + "plugin/swarm/removeSlaveLabels?name=" + name
-                    + "&secret=" + target.secret
-                    + SwarmClient.param("labels", labels));
+        post.addHeader("Connection", "close");
 
-            post.setDoAuthentication(true);
-            post.addRequestHeader("Connection", "close");
+        Crumb csrfCrumb = SwarmClient.getCsrfCrumb(client, context, target);
+        if (csrfCrumb != null) {
+            post.addHeader(csrfCrumb.crumbRequestField, csrfCrumb.crumb);
+        }
 
-            Crumb csrfCrumb = SwarmClient.getCsrfCrumb(client, target);
-            if (csrfCrumb != null) {
-                post.addRequestHeader(csrfCrumb.crumbRequestField, csrfCrumb.crumb);
-            }
-
-            int responseCode = client.executeMethod(post);
-            if (responseCode != HttpStatus.SC_OK) {
-                String msg = String.format("Failed to remove slave labels. %s - %s",
-                        responseCode,
-                        post.getResponseBodyAsString());
+        try (CloseableHttpResponse response = client.execute(post, context)) {
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                String msg =
+                        String.format(
+                                "Failed to remove slave labels. %s - %s",
+                                response.getStatusLine().getStatusCode(),
+                                EntityUtils.toString(response.getEntity(), UTF_8));
                 logger.log(Level.SEVERE, msg);
                 throw new RetryException(msg);
-            }
-        } finally {
-            if (post != null) {
-                post.releaseConnection();
             }
         }
     }
 
-    protected static synchronized void postLabelAppend(String name, String labels, HttpClient client, Candidate target) throws RetryException, IOException {
-        PostMethod post = null;
+    protected static synchronized void postLabelAppend(
+            String name,
+            String labels,
+            CloseableHttpClient client,
+            HttpClientContext context,
+            Candidate target)
+            throws IOException, RetryException {
+        HttpPost post =
+                new HttpPost(
+                        target.url
+                                + "plugin/swarm/addSlaveLabels?name="
+                                + name
+                                + "&secret="
+                                + target.secret
+                                + param("labels", labels));
 
-        try {
-            post = new PostMethod(target.url
-                    + "plugin/swarm/addSlaveLabels?name=" + name
-                    + "&secret=" + target.secret
-                    + param("labels", labels));
+        post.addHeader("Connection", "close");
 
-            post.setDoAuthentication(true);
-            post.addRequestHeader("Connection", "close");
+        Crumb csrfCrumb = getCsrfCrumb(client, context, target);
+        if (csrfCrumb != null) {
+            post.addHeader(csrfCrumb.crumbRequestField, csrfCrumb.crumb);
+        }
 
-            Crumb csrfCrumb = getCsrfCrumb(client, target);
-            if (csrfCrumb != null) {
-                post.addRequestHeader(csrfCrumb.crumbRequestField, csrfCrumb.crumb);
-            }
-
-            int responseCode = client.executeMethod(post);
-            if (responseCode != HttpStatus.SC_OK) {
-                String msg = String.format("Failed to update slave labels. Slave is probably messed up. %s - %s",
-                        responseCode,
-                        post.getResponseBodyAsString());
+        try (CloseableHttpResponse response = client.execute(post, context)) {
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                String msg =
+                        String.format(
+                                "Failed to update slave labels. Slave is probably messed up. %s - %s",
+                                response.getStatusLine().getStatusCode(),
+                                EntityUtils.toString(response.getEntity(), UTF_8));
                 logger.log(Level.SEVERE, msg);
                 throw new RetryException(msg);
-            }
-        } finally {
-            if (post != null) {
-                post.releaseConnection();
             }
         }
     }

--- a/client/src/main/java/hudson/plugins/swarm/XmlUtils.java
+++ b/client/src/main/java/hudson/plugins/swarm/XmlUtils.java
@@ -1,6 +1,5 @@
 package hudson.plugins.swarm;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.Level;
@@ -32,7 +31,7 @@ public final class XmlUtils {
      * @throws SAXException Error parsing the XML stream data e.g. badly formed XML.
      * @throws IOException Error reading from the steam.
      */
-    private static @Nonnull Document parse(@Nonnull InputStream stream)
+    public static @Nonnull Document parse(@Nonnull InputStream stream)
             throws IOException, SAXException {
         DocumentBuilder docBuilder;
 
@@ -44,20 +43,6 @@ public final class XmlUtils {
         }
 
         return docBuilder.parse(stream);
-    }
-
-    /**
-     * Parse the supplied XML file data to a {@link Document}.
-     *
-     * @param buf The input buffer.
-     * @return The parsed document.
-     * @throws SAXException Error parsing the XML file data e.g. badly formed XML.
-     * @throws IOException Error reading from the file.
-     */
-    public static @Nonnull Document parse(@Nonnull byte[] buf) throws SAXException, IOException {
-        try (InputStream inputStream = new ByteArrayInputStream(buf)) {
-            return parse(inputStream);
-        }
     }
 
     private static DocumentBuilderFactory newDocumentBuilderFactory() {

--- a/client/src/test/java/hudson/plugins/swarm/SwarmClientTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/SwarmClientTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import org.apache.commons.httpclient.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Test;
 
 public class SwarmClientTest {
@@ -26,7 +26,7 @@ public class SwarmClientTest {
         } catch (MalformedURLException e) {
             e.printStackTrace();
         }
-        HttpClient hc = swc.createHttpClient(url);
+        CloseableHttpClient hc = swc.createHttpClient(url);
         assertNotNull(hc);
     }
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,0 +1,24 @@
+# Proxy Configuration
+
+Swarm uses
+[`SystemDefaultHttpClient`](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/SystemDefaultHttpClient.html),
+which supports customization of the HTTP client through 18 different Java
+properties. Use the following system properties to configure a proxy:
+
+* `http.proxyHost`
+* `http.proxyPort`
+* `https.proxyHost`
+* `https.proxyPort`
+* `http.nonProxyHosts`
+
+For example:
+
+```
+java \
+	-Dhttp.proxyHost=127.0.0.1 \
+	-Dhttp.proxyPort=3128 \
+	-jar swarm-client.jar
+```
+
+For more information about these properties, see [the Java
+documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html).


### PR DESCRIPTION
### Problem

The project currently uses [Apache Commons HttpClient 3.x](https://hc.apache.org/httpclient-3.x/), which is EOL. It also doesn't have newer features like [`SystemDefaultHttpClient`](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/SystemDefaultHttpClient.html), which would be useful in fixing bugs like [JENKINS-42930](https://issues.jenkins-ci.org/browse/JENKINS-42930).

### Solution

Migrate to [Apache HttpComponents Client 4.x](https://hc.apache.org/httpcomponents-client-ga/index.html).

### Implementation

I largely followed these two guides:

- [Quick guide for Migration of Commons HttpClient 3.x to HttpComponents HttpClient 4.x](https://debuguide.blogspot.com/2013/01/quick-guide-for-migration-of-commons.html)
- [Migrating from HttpClient 3.1 to HttpClient 4.0](https://web.archive.org/web/20190205131053/http://blog.teamextension.com/migrating-from-httpclient-3-1-to-4-0-34)

I started by bumping the dependencies in `pom.xml` and migrating the imports as described in the tutorials above. Then I migrated the code to the 4.x syntax one method at a time. Most of the time, the migration was straightforward and obvious. The only non-obvious question was how to port the `setAuthenticationPreemptive(true)` lines from the old HTTP client, since no analogous functionality existed in the new client. Fortunately, I found [this article](https://www.baeldung.com/httpclient-4-basic-authentication), which explains how to do so in section 3 ("Preemptive Basic Authentication"). First, we need to create an [`HttpContext`](https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/protocol/HttpContext.html), pre-populating it with an authentication cache with the right type of authentication scheme preselected. This avoids the costly negotiation and ensures that basic authentication is chosen right off the bat. The article also explains how to verify this behavior by inspecting the logs.

As a bonus, I removed the `byte[]` version of `parse` from `XmlUtils`, which was encouraging a bad pattern of reading an `InputStream` into a `byte[]` in order to pass it into `XmlUtils` just so that `XmlUtils` could go and wrap it in a `ByteArrayInputStream`. With that method deleted, I was able to evaluate the callers and find that most of them already had direct access to the `InputStream` from the HTTP client and could pass it into the `InputStream` version of `parse` directly, which is more efficient.

### Testing

#104 added integration test coverage for all the code that does HTTP requests. I ran those same tests again and verified that coverage was still there. Other than that, the only additional testing I had to do was to ensure that preemptive authentication was taking place. I did so by running the Swarm Client with a username and password and with `ALL`-level logging, then ensuring the `Re-using cached 'basic' auth scheme` lines were present in the logs as described in section 3 of [this article](https://www.baeldung.com/httpclient-4-basic-authentication).