### PR TITLE
Cleanup logging.properties

### DIFF
--- a/client/logging.properties
+++ b/client/logging.properties
@@ -1,5 +1,5 @@
 ############################################################
-#      Default Logging Configuration File
+# Sample Logging Configuration File
 #
 # You can use a different file by specifying a filename
 # with the java.util.logging.config.file system property.
@@ -7,36 +7,30 @@
 ############################################################
 
 ############################################################
-#      Global properties
+# Global properties
 ############################################################
 
 # "handlers" specifies a comma separated list of log Handler
 # classes.  These handlers will be installed during VM startup.
 # Note that these classes must be on the system classpath.
-# By default we only configure a ConsoleHandler, which will only
-# show messages at the CONFIG and above levels.
-handlers= java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+handlers = java.util.logging.FileHandler, java.util.logging.ConsoleHandler
 
 # Default global logging level.
 # This specifies which kinds of events are logged across
-# all loggers.  For any given facility this global level
-# can be overriden by a facility specific level
-# Note that the ConsoleHandler also has a separate level
-# setting to limit messages printed to the console.
-.level= ALL
+# all loggers.  For any given handler or facility this global
+# level can be overriden.
+.level = ALL
 
 ############################################################
-# Handler specific properties.
-# Describes specific configuration info for Handlers.
+# Handler specific properties
 ############################################################
 
-# default file output is in user's home directory.
+java.util.logging.SimpleFormatter.format = %1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s %5$s%6$s%n
+
 java.util.logging.FileHandler.pattern = %h/swarm-client%u.log
 java.util.logging.FileHandler.limit = 20000000
 java.util.logging.FileHandler.count = 5
 java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
 
-# Limit the message that are printed on the console to CONFIG and above.
 java.util.logging.ConsoleHandler.level = CONFIG
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %2$s %5$s%6$s%n

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -11,8 +11,8 @@ logging](https://wiki.jenkins.io/display/JENKINS/Logging), including in
 following:
 
 ```
-handlers= java.util.logging.ConsoleHandler
-.level= INFO
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
 java.util.logging.ConsoleHandler.level = INFO
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 ```
@@ -30,9 +30,7 @@ To get more detailed logs from the Swarm client, create a custom
 verbose `logging.properties` file](../client/logging.properties). For example:
 
 ```
-java \
-	-Djava.util.logging.config.file='logging.properties' \
-	-jar swarm-client.jar
+java -Djava.util.logging.config.file='logging.properties' -jar swarm-client.jar
 ```
 
 For more information about the property file format, see the [Oracle


### PR DESCRIPTION
a) Consistent formatting.

b) Removing outdated and verbose comments.

c) ~~The global log level was changed from ALL to INFO in PR #67 some time ago,
   therefore not setting it for ConsoleHandler anymore.~~