### PR TITLE
Remove deprecated -logFile parameter

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -53,11 +53,6 @@ public class Client {
             System.exit(0);
         }
 
-        if (options.logFile != null) {
-            logger.severe("-logFile has been deprecated. Use logging properties file syntax instead: -Djava.util.logging.config.file=" + Paths.get("").toAbsolutePath().toString() + File.separator + "logging.properties");
-            System.exit(1);
-        }
-
         if (options.pidFile != null) {
             // This will return a string like 12345@hostname, so we need to do some string manipulation
             // to get the actual process identifier.

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -113,9 +113,6 @@ public class Options {
     @Option(name = "-labelsFile", usage = "File location with space delimited list of labels.  If the file changes, restarts this client.")
     public String labelsFile;
 
-    @Option(name = "-logFile", usage = "File to write STDOUT and STDERR to. (Deprecated, use -Djava.util.logging.config.file={path}logging.properties instead)")
-    public String logFile;
-
     @Option(name = "-pidFile", usage = "File to write PID to")
     public String pidFile;
 }


### PR DESCRIPTION
It was anyway implemented in way that it could not be used anymore.

This should properly be mentioned in the changelog and removed from the available options on the plugin's documentation page https://wiki.jenkins.io/display/JENKINS/Swarm+Plugin.