### PR TITLE
JENKINS-45295 Swarm Client should update labels on the fly when labelsFile changes

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -47,14 +47,17 @@ public class LabelFileWatcher implements Runnable {
     private String sFileName;
     private boolean bRunning = false;
     private Options opts;
+    private final String name;
     private String sLabels;
     private String[] sArgs;
     private Candidate targ;
 
-    public LabelFileWatcher(Candidate target, Options options, String... args) throws IOException {
+    public LabelFileWatcher(Candidate target, Options options, String name, String... args)
+            throws IOException {
         logger.config("LabelFileWatcher() constructed with: " + options.labelsFile + ", and " + StringUtils.join(args));
         targ = target;
         opts = options;
+        this.name = name;
         sFileName = options.labelsFile;
         sLabels = new String(Files.readAllBytes(Paths.get(sFileName)), UTF_8);
         sArgs = args;
@@ -124,7 +127,7 @@ public class LabelFileWatcher implements Runnable {
                 new HttpGet(
                         targ.getURL()
                                 + "/plugin/swarm/getSlaveLabels?name="
-                                + opts.name
+                                + name
                                 + "&secret="
                                 + targ.getSecret());
         try (CloseableHttpResponse response = h.execute(get, context)) {
@@ -162,7 +165,7 @@ public class LabelFileWatcher implements Runnable {
             sb.append(" ");
             if (sb.length() > 1000) {
                 try {
-                    SwarmClient.postLabelRemove(opts.name, sb.toString(), h, context, targ);
+                    SwarmClient.postLabelRemove(name, sb.toString(), h, context, targ);
                 } catch (IOException | RetryException e) {
                     String msg = "Exception when removing label from " + targ.getURL();
                     logger.log(Level.SEVERE, msg, e);
@@ -173,7 +176,7 @@ public class LabelFileWatcher implements Runnable {
         }
         if (sb.length() > 0) {
             try {
-                SwarmClient.postLabelRemove(opts.name, sb.toString(), h, context, targ);
+                SwarmClient.postLabelRemove(name, sb.toString(), h, context, targ);
             } catch (IOException | RetryException e) {
                 String msg = "Exception when removing label from " + targ.getURL();
                 logger.log(Level.SEVERE, msg, e);
@@ -190,7 +193,7 @@ public class LabelFileWatcher implements Runnable {
             sb.append(" ");
             if (sb.length() > 1000) {
                 try {
-                    SwarmClient.postLabelAppend(opts.name, sb.toString(), h, context, targ);
+                    SwarmClient.postLabelAppend(name, sb.toString(), h, context, targ);
                 } catch (IOException | RetryException e) {
                     String msg = "Exception when appending label to " + targ.getURL();
                     logger.log(Level.SEVERE, msg, e);
@@ -202,7 +205,7 @@ public class LabelFileWatcher implements Runnable {
 
         if (sb.length() > 0) {
             try {
-                SwarmClient.postLabelAppend(opts.name, sb.toString(), h, context, targ);
+                SwarmClient.postLabelAppend(name, sb.toString(), h, context, targ);
             } catch (IOException | RetryException e) {
                 String msg = "Exception when appending label to " + targ.getURL();
                 logger.log(Level.SEVERE, msg, e);

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -113,6 +113,10 @@ public class SwarmClient {
         return hash;
     }
 
+    public String getName() {
+        return name;
+    }
+
     public Candidate discoverFromBroadcast() throws IOException, RetryException {
         logger.config("discoverFromBroadcast() invoked");
 

--- a/plugin/src/test/java/hudson/plugins/swarm/PipelineJobTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/PipelineJobTest.java
@@ -59,7 +59,11 @@ public class PipelineJobTest {
         story.then(
                 s -> {
                     Node node =
-                            TestUtils.createSwarmClient(story.j, processDestroyer, temporaryFolder);
+                            TestUtils.createSwarmClient(
+                                    story.j,
+                                    processDestroyer,
+                                    temporaryFolder,
+                                    "-disableClientsUniqueId");
 
                     WorkflowJob project = story.j.createProject(WorkflowJob.class);
                     project.setConcurrentBuild(false);
@@ -70,7 +74,11 @@ public class PipelineJobTest {
                     tearDown();
 
                     TestUtils.createSwarmClient(
-                            node.getNodeName(), story.j, processDestroyer, temporaryFolder);
+                            node.getNodeName(),
+                            story.j,
+                            processDestroyer,
+                            temporaryFolder,
+                            "-disableClientsUniqueId");
                     SemaphoreStep.success("wait-0/1", null);
                     story.j.assertBuildStatusSuccess(story.j.waitForCompletion(build));
                     story.j.assertLogContains("ON_SWARM_CLIENT=true", build);
@@ -86,7 +94,11 @@ public class PipelineJobTest {
         story.then(
                 s -> {
                     Node node =
-                            TestUtils.createSwarmClient(story.j, processDestroyer, temporaryFolder);
+                            TestUtils.createSwarmClient(
+                                    story.j,
+                                    processDestroyer,
+                                    temporaryFolder,
+                                    "-disableClientsUniqueId");
 
                     WorkflowJob project = story.j.createProject(WorkflowJob.class);
                     File f1 = new File(story.j.jenkins.getRootDir(), "f1");
@@ -118,7 +130,11 @@ public class PipelineJobTest {
                     }
 
                     TestUtils.createSwarmClient(
-                            node.getNodeName(), story.j, processDestroyer, temporaryFolder);
+                            node.getNodeName(),
+                            story.j,
+                            processDestroyer,
+                            temporaryFolder,
+                            "-disableClientsUniqueId");
                     while (computer.isOffline()) {
                         Thread.sleep(100);
                     }

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -97,13 +97,11 @@ public class SwarmClientIntegrationTest {
         Set<String> toBeRemoved = new HashSet<>();
         toBeRemoved.add("toBeRemoved1");
         toBeRemoved.add("toBeRemoved2");
-        // TODO: Due to JENKINS-45295, this is busted unless we use "-disableClientsUniqueId".
         Node node =
                 TestUtils.createSwarmClient(
                         j,
                         processDestroyer,
                         temporaryFolder,
-                        "-disableClientsUniqueId",
                         "-labelsFile",
                         labelsFile.getAbsolutePath(),
                         "-labels",
@@ -118,8 +116,10 @@ public class SwarmClientIntegrationTest {
             writer.write(encode(expected));
         }
 
-        while (node.getLabelString().equals(origLabels)) {
-            Thread.sleep(100);
+        // TODO: This is a bit racy, since updates are not atomic.
+        while (node.getLabelString().equals(origLabels)
+                || decode(node.getLabelString()).equals(decode("swarm"))) {
+            Thread.sleep(1000);
         }
 
         expected.add("swarm");
@@ -133,13 +133,11 @@ public class SwarmClientIntegrationTest {
         Set<String> toBeRemoved = new HashSet<>();
         toBeRemoved.add(RandomStringUtils.randomAlphanumeric(500));
         toBeRemoved.add(RandomStringUtils.randomAlphanumeric(500));
-        // TODO: Due to JENKINS-45295, this is busted unless we use "-disableClientsUniqueId".
         Node node =
                 TestUtils.createSwarmClient(
                         j,
                         processDestroyer,
                         temporaryFolder,
-                        "-disableClientsUniqueId",
                         "-labelsFile",
                         labelsFile.getAbsolutePath(),
                         "-labels",
@@ -154,8 +152,10 @@ public class SwarmClientIntegrationTest {
             writer.write(encode(expected));
         }
 
-        while (node.getLabelString().equals(origLabels)) {
-            Thread.sleep(100);
+        // TODO: This is a bit racy, since updates are not atomic.
+        while (node.getLabelString().equals(origLabels)
+                || decode(node.getLabelString()).equals(decode("swarm"))) {
+            Thread.sleep(1000);
         }
 
         expected.add("swarm");


### PR DESCRIPTION
### Problem

In [JENKINS-45295](https://issues.jenkins-ci.org/browse/JENKINS-45295) and [JENKINS-48247](https://issues.jenkins-ci.org/browse/JENKINS-48247), users have reported that when the contents of the file specified by `-labelsFile` are changed, the client is blindly restarted, interrupting any running jobs. Needless to say, this is disruptive.

### Evaluation

`LabelFileWatcher` has two modes of operation: "soft" updates (which attempt to modify the labels in place) and "hard" updates (which restart the client, interrupting any running jobs). A soft update is first tried, followed by a hard update if the soft update is unsuccessful. I verified experimentally that after changing the labels file, a soft update was attempted and failed. Then the hard update was done, which restarted the client.

Why did the soft update fail? I stepped through the failure and saw that the soft update process made a call to the backend, but the backend returned a 404, claiming that a node by that name could not be found. Looking into this further, I saw that the node created on the backend had a [hash appended to it](https://github.com/jenkinsci/swarm-plugin/blob/321ffc3c320eef169eb7774dec3d35ef25d4b894/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java#L182-L185), while the node name being provided by the client did not have this hash. This provided the root cause: we were setting up the label watcher before the node had been named by the server. The requested name was not actually used by the server, but the label watcher thread was still trying to use it when communicating with the server.

Incidentally, the hash is only appended to the node name when `-disableClientsUniqueId` is _not_ provided, and I was able to work around the issue by passing in `-disableClientsUniqueId`.

### Solution

Create the node on the server before creating the label watcher thread, and use the name returned by the server when setting up the label watcher thread.

### Implementation

The implementation was pretty straightforward. I had to wean our test framework off `-disableClientsUniqueId` in order to be able to test this. I started by removing `-disableClientsUniqueId` from `TestUtils`, which entailed writing a custom `getComputer` function to iterate through nodes with a possible hash in the name. That having been done, we were no longer using `-disableClientsUniqueId` in `PipelineTest`, which needed it for tests that restart the agent. I added it back to just those tests. That having been done, I removed `disableClientsUniqueId` from the label tests.