### PR TITLE
Switch to SpotBugs

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci</groupId>
         <artifactId>jenkins</artifactId>
-        <version>1.51</version>
+        <version>1.52</version>
         <relativePath />
     </parent>
 
@@ -139,9 +139,9 @@
         <version>2.6</version>
       </dependency>
       <dependency>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>annotations</artifactId>
-          <version>3.0.1u2</version>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-annotations</artifactId>
+          <version>3.1.12</version>
           <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Updated the parent POM to [the latest version](https://github.com/jenkinsci/pom/releases), which has SpotBugs support, and migrated the annotations dependency from FindBugs to SpotBugs.