### PR TITLE
Build against recent LTS releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin()
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ],
+  [ platform: "windows", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ]
+])


### PR DESCRIPTION
A less ambitious version of #136 that just adds LTS releases to the matrix. Let's solve that problem first, and then deal with Java 11 support.