### PR TITLE
Avoid swarm agent description ending with ": null"

### DIFF
--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -209,7 +209,7 @@ public class PluginImpl extends Plugin {
                                     + req.getRemoteHost()
                                     + ((description == null || description.isEmpty())
                                             ? ""
-                                            : (" : " + description)),
+                                            : (": " + description)),
                             remoteFsRoot,
                             String.valueOf(executors),
                             mode,

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -202,10 +202,19 @@ public class PluginImpl extends Plugin {
                 }
             }
 
-            SwarmSlave slave = new SwarmSlave(name, "Swarm slave from " + req.getRemoteHost() +
-                    ( (description == null || description.isEmpty()) ? "" : (" : " + description) ),
-                    remoteFsRoot, String.valueOf(executors), mode,
-                    "swarm " + Util.fixNull(labels), nodeProperties);
+            SwarmSlave slave =
+                    new SwarmSlave(
+                            name,
+                            "Swarm slave from "
+                                    + req.getRemoteHost()
+                                    + ((description == null || description.isEmpty())
+                                            ? ""
+                                            : (" : " + description)),
+                            remoteFsRoot,
+                            String.valueOf(executors),
+                            mode,
+                            "swarm " + Util.fixNull(labels),
+                            nodeProperties);
 
             jenkins.addNode(slave);
             rsp.setContentType("text/plain; charset=iso-8859-1");

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -202,8 +202,10 @@ public class PluginImpl extends Plugin {
                 }
             }
 
-            SwarmSlave slave = new SwarmSlave(name, "Swarm slave from " + req.getRemoteHost() + " : " + description,
-                    remoteFsRoot, String.valueOf(executors), mode, "swarm " + Util.fixNull(labels), nodeProperties);
+            SwarmSlave slave = new SwarmSlave(name, "Swarm slave from " + req.getRemoteHost() +
+                    ( (description == null || description.isEmpty()) ? "" : (" : " + description) ),
+                    remoteFsRoot, String.valueOf(executors), mode,
+                    "swarm " + Util.fixNull(labels), nodeProperties);
 
             jenkins.addNode(slave);
             rsp.setContentType("text/plain; charset=iso-8859-1");

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.junit.After;
@@ -334,6 +335,26 @@ public class SwarmClientIntegrationTest {
 
     private static Set<String> decode(String labels) {
         return new HashSet<>(Arrays.asList(labels.split("\\s+")));
+    }
+
+    @Test
+    public void defaultDescription() throws Exception {
+        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder);
+        assertTrue(
+                node.getNodeDescription(),
+                Pattern.matches("Swarm slave from ([a-zA-Z_0-9-\\.]+)", node.getNodeDescription()));
+    }
+
+    @Test
+    public void customDescription() throws Exception {
+        Node node =
+                TestUtils.createSwarmClient(
+                        j, processDestroyer, temporaryFolder, "-description", "foobar");
+        assertTrue(
+                node.getNodeDescription(),
+                Pattern.matches(
+                        "Swarm slave from ([a-zA-Z_0-9-\\.]+) : foobar",
+                        node.getNodeDescription()));
     }
 
     @After

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -353,7 +353,7 @@ public class SwarmClientIntegrationTest {
         assertTrue(
                 node.getNodeDescription(),
                 Pattern.matches(
-                        "Swarm slave from ([a-zA-Z_0-9-\\.]+) : foobar",
+                        "Swarm slave from ([a-zA-Z_0-9-\\.]+): foobar",
                         node.getNodeDescription()));
     }
 


### PR DESCRIPTION
Only append a description if there is any, to the default prefix.