### PR TITLE
[JENKINS-44115] Remoting Work Directory Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,26 @@ $ java -jar swarm-client.jar --help
                                           (default: false)
  -disableSslVerification                : Disables SSL verification in the
                                           HttpClient. (default: false)
- -disableWorkDir                        : Disable Remoting Working Directory
-                                          and run agent in legacy mode.
-                                          (default: false)
+ -disableWorkDir                        : Disable Remoting working directory
+                                          support and run the agent in legacy
+                                          mode. (default: false)
  -e (--env)                             : An environment variable to be defined
                                           on this slave. It is specified as
                                           'key=value'. Multiple variables are
                                           allowed.
  -executors N                           : Number of executors (default: 16)
- -failIfWorkDirIsMissing                : Fail if workDir or internalDir are
-                                          missing. (default: false)
+ -failIfWorkDirIsMissing                : Fail if the requested Remoting
+                                          working directory or internal
+                                          directory is missing. (default: false)
  -fsroot FILE                           : Directory where Jenkins places files
                                           (default: .)
  -help (--help)                         : Show the help screen (default: true)
- -internalDir FILE                      : Remoting internal directory.
- -jar-cache FILE                        : Remoting jar cache directory.
+ -internalDir FILE                      : The name of the directory within the
+                                          Remoting working directory where
+                                          files internal to Remoting will be
+                                          stored.
+ -jar-cache FILE                        : Cache directory that stores JAR files
+                                          sent from the master.
  -labels VAL                            : Whitespace-separated list of labels
                                           to be assigned for this slave.
                                           Multiple options are allowed.
@@ -131,5 +136,6 @@ $ java -jar swarm-client.jar --help
                                           behavior
  -username VAL                          : The Jenkins username for
                                           authentication
- -workDir FILE                          : Remoting working directory.
+ -workDir FILE                          : The Remoting working directory where
+                                          the JAR cache and logs will be stored.
 ```

--- a/README.md
+++ b/README.md
@@ -56,10 +56,14 @@ $ java -jar swarm-client.jar --help
                                           on this slave. It is specified as
                                           'key=value'. Multiple variables are
                                           allowed.
- -executors N                           : Number of executors (default: 8)
+ -executors N                           : Number of executors (default: 16)
+ -failIfWorkDirIsMissing                : Fail if workDir or internalDir are
+                                          missing. (default: false)
  -fsroot FILE                           : Directory where Jenkins places files
                                           (default: .)
- -help (--help)                         : Show the help screen (default: false)
+ -help (--help)                         : Show the help screen (default: true)
+ -internalDir FILE                      : Remoting internal directory.
+ -jar-cache FILE                        : Remoting jar cache directory.
  -labels VAL                            : Whitespace-separated list of labels
                                           to be assigned for this slave.
                                           Multiple options are allowed.
@@ -127,4 +131,5 @@ $ java -jar swarm-client.jar --help
                                           behavior
  -username VAL                          : The Jenkins username for
                                           authentication
+ -workDir FILE                          : Remoting working directory.
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ $ java -jar swarm-client.jar --help
                                           (default: false)
  -disableSslVerification                : Disables SSL verification in the
                                           HttpClient. (default: false)
+ -disableWorkDir                        : Disable Remoting Working Directory
+                                          and run agent in legacy mode.
+                                          (default: false)
  -e (--env)                             : An environment variable to be defined
                                           on this slave. It is specified as
                                           'key=value'. Multiple variables are

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -126,27 +126,34 @@ public class Options {
                             + "and the previous process is still running.")
     public String pidFile;
 
-    @Option(name = "-disableWorkDir",
+    @Option(
+            name = "-disableWorkDir",
             usage = "Disable Remoting working directory support and run the agent in legacy mode.",
             forbids = {"-workDir", "-internalDir", "-failIfWorkDirIsMissing"})
     public boolean disableWorkDir = false;
 
-    @Option(name = "-workDir",
+    @Option(
+            name = "-workDir",
             usage = "The Remoting working directory where the JAR cache and logs will be stored.",
             forbids = "-disableWorkDir")
     public File workDir;
 
-    @Option(name = "-internalDir",
-            usage = "The name of the directory within the Remoting working directory where files internal to Remoting will be stored.",
+    @Option(
+            name = "-internalDir",
+            usage =
+                    "The name of the directory within the Remoting working directory where files internal to Remoting will be stored.",
             forbids = "-disableWorkDir")
     public File internalDir;
 
-    @Option(name = "-jar-cache",
+    @Option(
+            name = "-jar-cache",
             usage = "Cache directory that stores JAR files sent from the master.")
     public File jarCache;
 
-    @Option(name = "-failIfWorkDirIsMissing",
-            usage = "Fail if the requested Remoting working directory or internal directory is missing.",
+    @Option(
+            name = "-failIfWorkDirIsMissing",
+            usage =
+                    "Fail if the requested Remoting working directory or internal directory is missing.",
             forbids = "-disableWorkDir")
     public boolean failIfWorkDirIsMissing = false;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -146,7 +146,7 @@ public class Options {
     public File jarCache;
 
     @Option(name = "-failIfWorkDirIsMissing",
-            usage = "Fail if workDir or internalDir are missing ('false' by default)",
+            usage = "Fail if workDir or internalDir are missing ('false' by default).",
             forbids = {"-disableWorkDir"})
     public boolean failIfWokDirIsMissing = false;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -128,7 +128,7 @@ public class Options {
 
     @Option(name = "-disableWorkDir",
             usage = "Disable Remoting Working Directory and run agent in legacy mode.",
-            forbids = {"-workDir"})
+            forbids = {"-workDir", "-internalDir"})
     public boolean disableWorkDir = false;
 
     @Option(name = "-workDir",
@@ -136,4 +136,10 @@ public class Options {
             forbids = {"-disableWorkDir"}
     )
     public File workDir;
+
+    @Option(name = "-internalDir",
+            usage = "Remoting internal directory.",
+            forbids = {"-disableWorkDir"}
+    )
+    public File internalDir;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -129,4 +129,9 @@ public class Options {
     @Option(name = "-disableWorkDir",
             usage = "Disable Remoting Working Directory and run agent in legacy mode.")
     public boolean disableWorkDir = false;
+
+    @Option(name = "-workDir",
+            usage = "Remoting working directory"
+    )
+    public File workDir = remoteFsRoot;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -142,4 +142,8 @@ public class Options {
             forbids = {"-disableWorkDir"}
     )
     public File internalDir;
+
+    @Option(name = "-jar-cache",
+            usage = "Remoting jar cache directory.")
+    public File jarCache;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -146,7 +146,7 @@ public class Options {
     public File jarCache;
 
     @Option(name = "-failIfWorkDirIsMissing",
-            usage = "Fail if workDir or internalDir are missing ('false' by default).",
+            usage = "Fail if workDir or internalDir are missing.",
             forbids = {"-disableWorkDir"})
     public boolean failIfWokDirIsMissing = false;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -127,11 +127,13 @@ public class Options {
     public String pidFile;
 
     @Option(name = "-disableWorkDir",
-            usage = "Disable Remoting Working Directory and run agent in legacy mode.")
+            usage = "Disable Remoting Working Directory and run agent in legacy mode.",
+            forbids = {"-workDir"})
     public boolean disableWorkDir = false;
 
     @Option(name = "-workDir",
-            usage = "Remoting working directory"
+            usage = "Remoting working directory.",
+            forbids = {"-disableWorkDir"}
     )
     public File workDir = remoteFsRoot;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -128,22 +128,25 @@ public class Options {
 
     @Option(name = "-disableWorkDir",
             usage = "Disable Remoting Working Directory and run agent in legacy mode.",
-            forbids = {"-workDir", "-internalDir"})
+            forbids = {"-workDir", "-internalDir", "-failIfWorkDirIsMissing"})
     public boolean disableWorkDir = false;
 
     @Option(name = "-workDir",
             usage = "Remoting working directory.",
-            forbids = {"-disableWorkDir"}
-    )
+            forbids = {"-disableWorkDir"})
     public File workDir;
 
     @Option(name = "-internalDir",
             usage = "Remoting internal directory.",
-            forbids = {"-disableWorkDir"}
-    )
+            forbids = {"-disableWorkDir"})
     public File internalDir;
 
     @Option(name = "-jar-cache",
             usage = "Remoting jar cache directory.")
     public File jarCache;
+
+    @Option(name = "-failIfWorkDirIsMissing",
+            usage = "Fail if workDir or internalDir are missing ('false' by default)",
+            forbids = {"-disableWorkDir"})
+    public boolean failIfWokDirIsMissing = false;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -135,5 +135,5 @@ public class Options {
             usage = "Remoting working directory.",
             forbids = {"-disableWorkDir"}
     )
-    public File workDir = remoteFsRoot;
+    public File workDir;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -125,4 +125,8 @@ public class Options {
                     "File to write PID to. The client will refuse to start if this file exists "
                             + "and the previous process is still running.")
     public String pidFile;
+
+    @Option(name = "-disableWorkDir",
+            usage = "Disable Remoting Working Directory and run agent in legacy mode.")
+    public boolean disableWorkDir = false;
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -127,26 +127,26 @@ public class Options {
     public String pidFile;
 
     @Option(name = "-disableWorkDir",
-            usage = "Disable Remoting Working Directory and run agent in legacy mode.",
+            usage = "Disable Remoting working directory support and run the agent in legacy mode.",
             forbids = {"-workDir", "-internalDir", "-failIfWorkDirIsMissing"})
     public boolean disableWorkDir = false;
 
     @Option(name = "-workDir",
-            usage = "Remoting working directory.",
-            forbids = {"-disableWorkDir"})
+            usage = "The Remoting working directory where the JAR cache and logs will be stored.",
+            forbids = "-disableWorkDir")
     public File workDir;
 
     @Option(name = "-internalDir",
-            usage = "Remoting internal directory.",
-            forbids = {"-disableWorkDir"})
+            usage = "The name of the directory within the Remoting working directory where files internal to Remoting will be stored.",
+            forbids = "-disableWorkDir")
     public File internalDir;
 
     @Option(name = "-jar-cache",
-            usage = "Remoting jar cache directory.")
+            usage = "Cache directory that stores JAR files sent from the master.")
     public File jarCache;
 
     @Option(name = "-failIfWorkDirIsMissing",
-            usage = "Fail if workDir or internalDir are missing.",
-            forbids = {"-disableWorkDir"})
-    public boolean failIfWokDirIsMissing = false;
+            usage = "Fail if the requested Remoting working directory or internal directory is missing.",
+            forbids = "-disableWorkDir")
+    public boolean failIfWorkDirIsMissing = false;
 }

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -223,8 +223,10 @@ public class SwarmClient {
         }
 
         if (!options.disableWorkDir) {
-            final String workDirPath = options.workDir != null
-                    ? options.workDir.getPath() : options.remoteFsRoot.getPath();
+            final String workDirPath =
+                    options.workDir != null
+                            ? options.workDir.getPath()
+                            : options.remoteFsRoot.getPath();
             args.add("-workDir");
             args.add(workDirPath);
 

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -221,6 +221,12 @@ public class SwarmClient {
             args.add("-credentials");
             args.add(options.username + ":" + options.password);
         }
+
+        if (!options.disableWorkDir) {
+            args.add("-workDir");
+            args.add(".");
+        }
+
         args.add("-headless");
         args.add("-noreconnect");
 

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -233,7 +233,7 @@ public class SwarmClient {
                 args.add(options.internalDir.getPath());
             }
 
-            if (options.failIfWokDirIsMissing) {
+            if (options.failIfWorkDirIsMissing) {
                 args.add("-failIfWorkDirIsMissing");
             }
         }

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -234,6 +234,11 @@ public class SwarmClient {
             }
         }
 
+        if (options.jarCache != null) {
+            args.add("-jar-cache");
+            args.add(options.jarCache.getPath());
+        }
+
         args.add("-headless");
         args.add("-noreconnect");
 

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -227,6 +227,11 @@ public class SwarmClient {
                     ? options.workDir.getPath() : options.remoteFsRoot.getPath();
             args.add("-workDir");
             args.add(workDirPath);
+
+            if (options.internalDir != null) {
+                args.add("-internalDir");
+                args.add(options.internalDir.getPath());
+            }
         }
 
         args.add("-headless");

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -224,7 +224,7 @@ public class SwarmClient {
 
         if (!options.disableWorkDir) {
             args.add("-workDir");
-            args.add(".");
+            args.add(options.workDir.getPath());
         }
 
         args.add("-headless");

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -223,8 +223,10 @@ public class SwarmClient {
         }
 
         if (!options.disableWorkDir) {
+            final String workDirPath = options.workDir != null
+                    ? options.workDir.getPath() : options.remoteFsRoot.getPath();
             args.add("-workDir");
-            args.add(options.workDir.getPath());
+            args.add(workDirPath);
         }
 
         args.add("-headless");

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -232,6 +232,10 @@ public class SwarmClient {
                 args.add("-internalDir");
                 args.add(options.internalDir.getPath());
             }
+
+            if (options.failIfWokDirIsMissing) {
+                args.add("-failIfWorkDirIsMissing");
+            }
         }
 
         if (options.jarCache != null) {

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -386,6 +387,33 @@ public class SwarmClientIntegrationTest {
                         + Files.readAllLines(stderr.toPath()),
                 Files.readAllLines(stderr.toPath()).stream()
                         .anyMatch(line -> line.contains("Option \"-master\" is required")));
+    }
+
+    @Test
+    public void workDirEnabledByDefaultWithFsRootAsDefaultPath() throws Exception {
+        final File fsRootPath = temporaryFolder.newFolder("fsrootdir");
+        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+                "-fsroot", fsRootPath.getAbsolutePath());
+
+        assertTrue("Workdir created by default", Files.isDirectory(new File(fsRootPath, "remoting").toPath()));
+    }
+
+    @Test
+    public void workDirWithCustomPath() throws Exception {
+        final File workDirPath = temporaryFolder.newFolder("customworkdir");
+        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+                "-workDir", workDirPath.getAbsolutePath());
+
+        assertTrue("Custom workdir created", Files.isDirectory(new File(workDirPath, "remoting").toPath()));
+    }
+
+    @Test
+    public void disableWorkDirRunsInLegacyMode() throws Exception {
+        final File fsRootPath = temporaryFolder.newFolder("fsrootdir");
+        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+                "-fsroot", fsRootPath.getAbsolutePath(), "-disableWorkDir");
+
+        assertFalse("Workdir not created", Files.isDirectory(new File(fsRootPath, "remoting").toPath()));
     }
 
     @After

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -11,7 +11,11 @@ import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
@@ -25,10 +29,17 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class SwarmClientIntegrationTest {
 

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -397,7 +397,10 @@ public class SwarmClientIntegrationTest {
         TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath());
 
-        assertTrue("Workdir exists", new File(fsRootPath, "remoting").isDirectory());
+        assertDirectories(fsRootPath,
+                new File(fsRootPath, "remoting"),
+                new File(fsRootPath, "remoting/logs"),
+                new File(fsRootPath, "remoting/jarCache"));
     }
 
     @Test
@@ -406,7 +409,10 @@ public class SwarmClientIntegrationTest {
         TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-workDir", workDirPath.getAbsolutePath());
 
-        assertTrue("Custom workdir exists", new File(workDirPath, "remoting").isDirectory());
+        assertDirectories(workDirPath,
+                new File(workDirPath, "remoting"),
+                new File(workDirPath, "remoting/logs"),
+                new File(workDirPath, "remoting/jarCache"));
     }
 
     @Test
@@ -415,7 +421,10 @@ public class SwarmClientIntegrationTest {
         TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath(), "-disableWorkDir");
 
-        assertFalse("Workdir not exists", new File(fsRootPath, "remoting").isDirectory());
+        assertDirectories(fsRootPath);
+        assertNoDirectories(new File(fsRootPath, "remoting"),
+                new File(fsRootPath, "remoting/logs"),
+                new File(fsRootPath, "remoting/jarCache"));
     }
 
     @Test
@@ -426,7 +435,10 @@ public class SwarmClientIntegrationTest {
                 "-fsroot", fsRootPath.getAbsolutePath(), "-workDir", workDirPath.getParent(),
                 "-failIfWorkDirIsMissing");
 
-        assertTrue("Custom workdir exists", workDirPath.isDirectory());
+        assertDirectories(fsRootPath,
+                workDirPath,
+                new File(workDirPath, "logs"),
+                new File(workDirPath, "jarCache"));
     }
 
     @Test
@@ -440,7 +452,11 @@ public class SwarmClientIntegrationTest {
 
         node.process.waitFor();
         assertEquals("Process fails", 1, node.process.exitValue());
-        assertFalse("Custom workdir not exists", new File(workDirPath, "remoting").isDirectory());
+
+        assertDirectories(fsRootPath);
+        assertNoDirectories(new File(fsRootPath, "remoting"),
+                new File(fsRootPath, "remoting/logs"),
+                new File(fsRootPath, "remoting/jarCache"));
     }
 
     @Test
@@ -449,8 +465,10 @@ public class SwarmClientIntegrationTest {
         TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath());
 
-        assertTrue("Internal dir logs exists", new File(fsRootPath, "remoting/logs").isDirectory());
-        assertTrue("Internal dir jarcache exists", new File(fsRootPath, "remoting/jarCache").isDirectory());
+        assertDirectories(fsRootPath,
+                new File(fsRootPath, "remoting"),
+                new File(fsRootPath, "remoting/logs"),
+                new File(fsRootPath, "remoting/jarCache"));
     }
 
     @Test
@@ -459,8 +477,10 @@ public class SwarmClientIntegrationTest {
         TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath(), "-internalDir", "custominternaldir");
 
-        assertTrue("Internal dir logs exists", new File(fsRootPath, "custominternaldir/logs").isDirectory());
-        assertTrue("Internal dir jarcache exists", new File(fsRootPath, "custominternaldir/jarCache").isDirectory());
+        assertDirectories(fsRootPath,
+                new File(fsRootPath, "custominternaldir"),
+                new File(fsRootPath, "custominternaldir/logs"),
+                new File(fsRootPath, "custominternaldir/jarCache"));
     }
 
     @Test
@@ -470,7 +490,10 @@ public class SwarmClientIntegrationTest {
         TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath(), "-jar-cache", jarCachePath.getPath());
 
-        assertTrue("Internal dir jarcache exists", jarCachePath.isDirectory());
+        assertDirectories(fsRootPath,
+                new File(fsRootPath, "remoting"),
+                new File(fsRootPath, "remoting/logs"),
+                jarCachePath);
     }
 
     @After
@@ -481,5 +504,13 @@ public class SwarmClientIntegrationTest {
             e.printStackTrace(System.err);
         }
         Files.deleteIfExists(getPidFile().toPath());
+    }
+
+    private void assertDirectories(File... paths) {
+        Arrays.stream(paths).forEach(path -> assertTrue(path.getPath() + " exists", path.isDirectory()));
+    }
+
+    private void assertNoDirectories(File... paths) {
+        Arrays.stream(paths).forEach(path -> assertFalse(path.getPath() + " not exists", path.isDirectory()));
     }
 }

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -1,5 +1,10 @@
 package hudson.plugins.swarm;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -9,6 +14,17 @@ import hudson.plugins.swarm.test.TestUtils;
 import hudson.tasks.BatchFile;
 import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.junit.After;
@@ -23,23 +39,6 @@ import org.jvnet.hudson.test.JenkinsRule;
 import oshi.SystemInfo;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OperatingSystem;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Pattern;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class SwarmClientIntegrationTest {
 
@@ -394,10 +393,11 @@ public class SwarmClientIntegrationTest {
     @Test
     public void workDirEnabledByDefaultWithFsRootAsDefaultPath() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
-                "-fsroot", fsRootPath.getAbsolutePath());
+        TestUtils.createSwarmClient(
+                j, processDestroyer, temporaryFolder, "-fsroot", fsRootPath.getAbsolutePath());
 
-        assertDirectories(fsRootPath,
+        assertDirectories(
+                fsRootPath,
                 new File(fsRootPath, "remoting"),
                 new File(fsRootPath, "remoting/logs"),
                 new File(fsRootPath, "remoting/jarCache"));
@@ -406,10 +406,11 @@ public class SwarmClientIntegrationTest {
     @Test
     public void workDirWithCustomPath() throws Exception {
         final File workDirPath = new File(temporaryRemotingFolder.getRoot(), "customworkdir");
-        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
-                "-workDir", workDirPath.getAbsolutePath());
+        TestUtils.createSwarmClient(
+                j, processDestroyer, temporaryFolder, "-workDir", workDirPath.getAbsolutePath());
 
-        assertDirectories(workDirPath,
+        assertDirectories(
+                workDirPath,
                 new File(workDirPath, "remoting"),
                 new File(workDirPath, "remoting/logs"),
                 new File(workDirPath, "remoting/jarCache"));
@@ -418,11 +419,17 @@ public class SwarmClientIntegrationTest {
     @Test
     public void disableWorkDirRunsInLegacyMode() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
-                "-fsroot", fsRootPath.getAbsolutePath(), "-disableWorkDir");
+        TestUtils.createSwarmClient(
+                j,
+                processDestroyer,
+                temporaryFolder,
+                "-fsroot",
+                fsRootPath.getAbsolutePath(),
+                "-disableWorkDir");
 
         assertDirectories(fsRootPath);
-        assertNoDirectories(new File(fsRootPath, "remoting"),
+        assertNoDirectories(
+                new File(fsRootPath, "remoting"),
                 new File(fsRootPath, "remoting/logs"),
                 new File(fsRootPath, "remoting/jarCache"));
     }
@@ -431,11 +438,18 @@ public class SwarmClientIntegrationTest {
     public void failIfWorkDirIsMissingDoesNothingIfDirectoryExists() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         final File workDirPath = temporaryFolder.newFolder("remoting");
-        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
-                "-fsroot", fsRootPath.getAbsolutePath(), "-workDir", workDirPath.getParent(),
+        TestUtils.createSwarmClient(
+                j,
+                processDestroyer,
+                temporaryFolder,
+                "-fsroot",
+                fsRootPath.getAbsolutePath(),
+                "-workDir",
+                workDirPath.getParent(),
                 "-failIfWorkDirIsMissing");
 
-        assertDirectories(fsRootPath,
+        assertDirectories(
+                fsRootPath,
                 workDirPath,
                 new File(workDirPath, "logs"),
                 new File(workDirPath, "jarCache"));
@@ -445,16 +459,30 @@ public class SwarmClientIntegrationTest {
     public void failIfWorkDirIsMissingFailsOnMissingWorkDir() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         final File workDirPath = new File(temporaryRemotingFolder.getRoot(), "customworkdir");
-        TestUtils.SwarmClientProcessWrapper node = TestUtils.runSwarmClient("should_fail",
-                j, processDestroyer, temporaryFolder,
-                "-fsroot", fsRootPath.getAbsolutePath(), "-workDir", workDirPath.getAbsolutePath(),
-                "-retry", "0", "-retryInterval", "0", "-maxRetryInterval", "0", "-failIfWorkDirIsMissing");
+        TestUtils.SwarmClientProcessWrapper node =
+                TestUtils.runSwarmClient(
+                        "should_fail",
+                        j,
+                        processDestroyer,
+                        temporaryFolder,
+                        "-fsroot",
+                        fsRootPath.getAbsolutePath(),
+                        "-workDir",
+                        workDirPath.getAbsolutePath(),
+                        "-retry",
+                        "0",
+                        "-retryInterval",
+                        "0",
+                        "-maxRetryInterval",
+                        "0",
+                        "-failIfWorkDirIsMissing");
 
         node.process.waitFor();
         assertEquals("Process fails", 1, node.process.exitValue());
 
         assertDirectories(fsRootPath);
-        assertNoDirectories(new File(fsRootPath, "remoting"),
+        assertNoDirectories(
+                new File(fsRootPath, "remoting"),
                 new File(fsRootPath, "remoting/logs"),
                 new File(fsRootPath, "remoting/jarCache"));
     }
@@ -462,10 +490,11 @@ public class SwarmClientIntegrationTest {
     @Test
     public void internalDirIsInWorkDirByDefault() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
-                "-fsroot", fsRootPath.getAbsolutePath());
+        TestUtils.createSwarmClient(
+                j, processDestroyer, temporaryFolder, "-fsroot", fsRootPath.getAbsolutePath());
 
-        assertDirectories(fsRootPath,
+        assertDirectories(
+                fsRootPath,
                 new File(fsRootPath, "remoting"),
                 new File(fsRootPath, "remoting/logs"),
                 new File(fsRootPath, "remoting/jarCache"));
@@ -474,10 +503,17 @@ public class SwarmClientIntegrationTest {
     @Test
     public void internalDirWithCustomPath() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
-                "-fsroot", fsRootPath.getAbsolutePath(), "-internalDir", "custominternaldir");
+        TestUtils.createSwarmClient(
+                j,
+                processDestroyer,
+                temporaryFolder,
+                "-fsroot",
+                fsRootPath.getAbsolutePath(),
+                "-internalDir",
+                "custominternaldir");
 
-        assertDirectories(fsRootPath,
+        assertDirectories(
+                fsRootPath,
                 new File(fsRootPath, "custominternaldir"),
                 new File(fsRootPath, "custominternaldir/logs"),
                 new File(fsRootPath, "custominternaldir/jarCache"));
@@ -487,10 +523,17 @@ public class SwarmClientIntegrationTest {
     public void jarCacheWithCustomPath() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         final File jarCachePath = new File(temporaryRemotingFolder.getRoot(), "customjarcache");
-        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
-                "-fsroot", fsRootPath.getAbsolutePath(), "-jar-cache", jarCachePath.getPath());
+        TestUtils.createSwarmClient(
+                j,
+                processDestroyer,
+                temporaryFolder,
+                "-fsroot",
+                fsRootPath.getAbsolutePath(),
+                "-jar-cache",
+                jarCachePath.getPath());
 
-        assertDirectories(fsRootPath,
+        assertDirectories(
+                fsRootPath,
                 new File(fsRootPath, "remoting"),
                 new File(fsRootPath, "remoting/logs"),
                 jarCachePath);
@@ -507,10 +550,12 @@ public class SwarmClientIntegrationTest {
     }
 
     private void assertDirectories(File... paths) {
-        Arrays.stream(paths).forEach(path -> assertTrue(path.getPath() + " exists", path.isDirectory()));
+        Arrays.stream(paths)
+                .forEach(path -> assertTrue(path.getPath() + " exists", path.isDirectory()));
     }
 
     private void assertNoDirectories(File... paths) {
-        Arrays.stream(paths).forEach(path -> assertFalse(path.getPath() + " not exists", path.isDirectory()));
+        Arrays.stream(paths)
+                .forEach(path -> assertFalse(path.getPath() + " not exists", path.isDirectory()));
     }
 }

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -1,10 +1,5 @@
 package hudson.plugins.swarm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
@@ -14,25 +9,9 @@ import hudson.plugins.swarm.test.TestUtils;
 import hudson.tasks.BatchFile;
 import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
-import java.io.File;
-import java.io.IOException;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Pattern;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
@@ -40,6 +19,16 @@ import org.jvnet.hudson.test.JenkinsRule;
 import oshi.SystemInfo;
 import oshi.software.os.OSProcess;
 import oshi.software.os.OperatingSystem;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
 
 public class SwarmClientIntegrationTest {
 
@@ -394,39 +383,39 @@ public class SwarmClientIntegrationTest {
     @Test
     public void workDirEnabledByDefaultWithFsRootAsDefaultPath() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath());
 
-        assertTrue("Workdir created by default", Files.isDirectory(new File(fsRootPath, "remoting").toPath()));
+        assertTrue("Workdir exists", new File(fsRootPath, "remoting").isDirectory());
     }
 
     @Test
     public void workDirWithCustomPath() throws Exception {
         final File workDirPath = new File(temporaryRemotingFolder.getRoot(), "customworkdir");
-        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-workDir", workDirPath.getAbsolutePath());
 
-        assertTrue("Custom workdir created", Files.isDirectory(new File(workDirPath, "remoting").toPath()));
+        assertTrue("Custom workdir exists", new File(workDirPath, "remoting").isDirectory());
     }
 
     @Test
     public void disableWorkDirRunsInLegacyMode() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath(), "-disableWorkDir");
 
-        assertFalse("Workdir not created", Files.isDirectory(new File(fsRootPath, "remoting").toPath()));
+        assertFalse("Workdir not exists", new File(fsRootPath, "remoting").isDirectory());
     }
 
     @Test
     public void failIfWorkDirIsMissingDoesNothingIfDirectoryExists() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         final File workDirPath = temporaryFolder.newFolder("remoting");
-        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath(), "-workDir", workDirPath.getParent(),
                 "-failIfWorkDirIsMissing");
 
-        assertTrue("Custom workdir created", Files.isDirectory(workDirPath.toPath()));
+        assertTrue("Custom workdir exists", workDirPath.isDirectory());
     }
 
     @Test
@@ -440,37 +429,37 @@ public class SwarmClientIntegrationTest {
 
         node.process.waitFor();
         assertEquals("Process fails", 1, node.process.exitValue());
-        assertFalse("Custom workdir not created", Files.isDirectory(new File(workDirPath, "remoting").toPath()));
+        assertFalse("Custom workdir not exists", new File(workDirPath, "remoting").isDirectory());
     }
 
     @Test
     public void internalDirIsInWorkDirByDefault() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath());
 
-        assertTrue("Internal dir logs exists", Files.isDirectory(new File(fsRootPath, "remoting/logs").toPath()));
-        assertTrue("Internal dir jarcache exists", Files.isDirectory(new File(fsRootPath, "remoting/jarCache").toPath()));
+        assertTrue("Internal dir logs exists", new File(fsRootPath, "remoting/logs").isDirectory());
+        assertTrue("Internal dir jarcache exists", new File(fsRootPath, "remoting/jarCache").isDirectory());
     }
 
     @Test
     public void internalDirWithCustomPath() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath(), "-internalDir", "custominternaldir");
 
-        assertTrue("Internal dir logs exists", Files.isDirectory(new File(fsRootPath, "custominternaldir/logs").toPath()));
-        assertTrue("Internal dir jarcache exists", Files.isDirectory(new File(fsRootPath, "custominternaldir/jarCache").toPath()));
+        assertTrue("Internal dir logs exists", new File(fsRootPath, "custominternaldir/logs").isDirectory());
+        assertTrue("Internal dir jarcache exists", new File(fsRootPath, "custominternaldir/jarCache").isDirectory());
     }
 
     @Test
     public void jarCacheWithCustomPath() throws Exception {
         final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         final File jarCachePath = new File(temporaryRemotingFolder.getRoot(), "customjarcache");
-        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+        TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath(), "-jar-cache", jarCachePath.getPath());
 
-        assertTrue("Internal dir jarcache exists", Files.isDirectory(jarCachePath.toPath()));
+        assertTrue("Internal dir jarcache exists", jarCachePath.isDirectory());
     }
 
     @After

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -438,6 +438,16 @@ public class SwarmClientIntegrationTest {
         assertTrue("Internal dir jarcache exists", Files.isDirectory(new File(fsRootPath, "custominternaldir/jarCache").toPath()));
     }
 
+    @Test
+    public void jarCacheWithCustomPath() throws Exception {
+        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        final File jarCachePath = new File(temporaryRemotingFolder.getRoot(), "customjarcache");
+        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+                "-fsroot", fsRootPath.getAbsolutePath(), "-jar-cache", jarCachePath.getPath());
+
+        assertTrue("Internal dir jarcache exists", Files.isDirectory(jarCachePath.toPath()));
+    }
+
     @After
     public void tearDown() throws IOException {
         try {

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -49,6 +49,8 @@ public class SwarmClientIntegrationTest {
 
     @ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+    @Rule public TemporaryFolder temporaryRemotingFolder = new TemporaryFolder();
+
     private final OperatingSystem os = new SystemInfo().getOperatingSystem();
 
     private final ProcessDestroyer processDestroyer = new ProcessDestroyer();
@@ -391,7 +393,7 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void workDirEnabledByDefaultWithFsRootAsDefaultPath() throws Exception {
-        final File fsRootPath = temporaryFolder.newFolder("fsrootdir");
+        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath());
 
@@ -400,7 +402,7 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void workDirWithCustomPath() throws Exception {
-        final File workDirPath = temporaryFolder.newFolder("customworkdir");
+        final File workDirPath = temporaryRemotingFolder.newFolder("customworkdir");
         Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-workDir", workDirPath.getAbsolutePath());
 
@@ -409,7 +411,7 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void disableWorkDirRunsInLegacyMode() throws Exception {
-        final File fsRootPath = temporaryFolder.newFolder("fsrootdir");
+        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
                 "-fsroot", fsRootPath.getAbsolutePath(), "-disableWorkDir");
 

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -418,6 +418,26 @@ public class SwarmClientIntegrationTest {
         assertFalse("Workdir not created", Files.isDirectory(new File(fsRootPath, "remoting").toPath()));
     }
 
+    @Test
+    public void internalDirIsInWorkDirByDefault() throws Exception {
+        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+                "-fsroot", fsRootPath.getAbsolutePath());
+
+        assertTrue("Internal dir logs exists", Files.isDirectory(new File(fsRootPath, "remoting/logs").toPath()));
+        assertTrue("Internal dir jarcache exists", Files.isDirectory(new File(fsRootPath, "remoting/jarCache").toPath()));
+    }
+
+    @Test
+    public void internalDirWithCustomPath() throws Exception {
+        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        Node node = TestUtils.createSwarmClient(j, processDestroyer, temporaryFolder,
+                "-fsroot", fsRootPath.getAbsolutePath(), "-internalDir", "custominternaldir");
+
+        assertTrue("Internal dir logs exists", Files.isDirectory(new File(fsRootPath, "custominternaldir/logs").toPath()));
+        assertTrue("Internal dir jarcache exists", Files.isDirectory(new File(fsRootPath, "custominternaldir/jarCache").toPath()));
+    }
+
     @After
     public void tearDown() throws IOException {
         try {

--- a/plugin/src/test/java/hudson/plugins/swarm/test/TestUtils.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/TestUtils.java
@@ -137,6 +137,7 @@ public class TestUtils {
         Collections.addAll(command, args);
 
         ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(temporaryFolder.newFolder());
         pb.environment().put("ON_SWARM_CLIENT", "true");
         File stdout = File.createTempFile("stdout", ".log", temporaryFolder.getRoot());
         pb.redirectOutput(stdout);


### PR DESCRIPTION
Enables the _Remoting Working Directory_ (`-workDir`) by default ([JENKINS-44115](https://issues.jenkins-ci.org/browse/JENKINS-44115)).

For backwards compatibility I have added the `-disableWorkDir` option which runs the legacy mode again (as it's now). However, I'm not sure if that's really needed.

----------------------

- [x] Rebase onto master
- [x] Default _-workDir_ to _fsRoot_
- [x] _-workDir_
- [x] _-disableWorkDir_ 
- [x] _-internalDir_
- [x] _-failIfWorkDirIsMissing_
- [x] _-jar-cache_
- [x] Default _-jar-cache_ to _${workDir}/${internalDir}/jarCache_
- [x] Update readme
- [x] Additional assertions (Test)


