### PR TITLE
[JENKINS-62033] - Want a way to disable SSL hostname verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,16 @@ $ java -jar swarm-client.jar --help
  -description VAL                       : Description to be put on the slave
  -disableClientsUniqueId                : Disables client's unique ID.
                                           (default: false)
- -disableSslVerification                : Disables SSL verification in the
-                                          HttpClient. (default: false)
+ -disableSslHostnameVerification        : Disables SSL hostname verification in
+                                          the HTTP client. Note that SSL
+                                          hostname verification should not be
+                                          confused with SSL trust verification.
+                                          (default: false)
+ -disableSslVerification                : Disables SSL trust verification in
+                                          the HTTP client. Note that SSL trust
+                                          verification should not be confused
+                                          with SSL hostname verification.
+                                          (default: false)
  -disableWorkDir                        : Disable Remoting working directory
                                           support and run the agent in legacy
                                           mode. (default: false)

--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -31,11 +31,12 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -81,7 +82,12 @@ public class LabelFileWatcher implements Runnable {
             }
         }
 
-        return HttpClients.createSystem();
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        builder.useSystemProperties();
+        if (opts.disableSslHostnameVerification) {
+            builder.setSSLHostnameVerifier(new NoopHostnameVerifier());
+        }
+        return builder.build();
     }
 
     private HttpClientContext createHttpClientContext(URL urlForAuth) {

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -55,7 +55,12 @@ public class Options {
     @Option(name = "-maxRetryInterval", usage = "Max time to wait before retry in seconds. Default is 60 seconds.")
     public int maxRetryInterval = 60;
 
-    @Option(name = "-disableSslVerification", usage = "Disables SSL verification in the HttpClient.")
+    @Option(
+            name = "-disableSslVerification",
+            usage =
+                    "Disables SSL trust verification in the HTTP client. Note that SSL trust "
+                            + "verification should not be confused with SSL hostname "
+                            + "verification.")
     public boolean disableSslVerification;
 
     @Option(name = "-sslFingerprints", usage = "Whitespace-separated list of accepted certificate fingerprints (SHA-256/Hex), "+
@@ -63,6 +68,14 @@ public class Options {
                                                "No revocation, expiration or not yet valid check will be performed " +
                                                "for custom fingerprints! Multiple options are allowed.")
     public String sslFingerprints = "";
+
+    @Option(
+            name = "-disableSslHostnameVerification",
+            usage =
+                    "Disables SSL hostname verification in the HTTP client. Note that SSL "
+                            + "hostname verification should not be confused with SSL trust "
+                            + "verification.")
+    public boolean disableSslHostnameVerification = false;
 
     @Option(name = "-disableClientsUniqueId", usage = "Disables client's unique ID.")
     public boolean disableClientsUniqueId;


### PR DESCRIPTION
See [JENKINS-62033](https://issues.jenkins-ci.org/browse/JENKINS-62033). Clarifies the documentation for the existing `-disableSslVerification` option to explain that it refers only to SSL trust verification. Adds a new `-disableSslHostnameVerification` option to disable SSL hostname verification. I tested this with a self-signed certificate whose hostname didn't match the actual hostname of the machine. Before this change, I got the same error as the user reported in the bug. After using the new `-disableSslHostnameVerification` option I was able to connect successfully.