### PR TITLE
[JENKINS-62033] - Swarm client -disableSslVerification option does not disable SSL hostname verification

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -31,11 +31,12 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -81,7 +82,12 @@ public class LabelFileWatcher implements Runnable {
             }
         }
 
-        return HttpClients.createSystem();
+        HttpClientBuilder builder = HttpClientBuilder.create();
+        builder.useSystemProperties();
+        if (opts.disableSslVerification) {
+            builder.setSSLHostnameVerifier(new NoopHostnameVerifier());
+        }
+        return builder.build();
     }
 
     private HttpClientContext createHttpClientContext(URL urlForAuth) {


### PR DESCRIPTION
See [JENKINS-62033](https://issues.jenkins-ci.org/browse/JENKINS-62033). A simpler version of #199. Enhances the existing `-disableSslVerification` option to also disable SSL hostname verification. This matches the semantics of the Remoting library. I tested this with a few configurations:

- A self-signed certificate with a correct hostname and `-sslFingerprints`. This worked correctly without needing to use `-disableSslVerification`. I suspect most users who care about SSL will be using either this method or (even better) a CA-signed certificate.
- A self-signed certificate with an incorrect hostname. This didn't work with `-sslFingerprints` as expected, reproducing the exception from the bug. Adding `-disableSslVerification` allowed the connection.