### PR TITLE
Minor cleanup of SwarmLauncher

### DIFF
--- a/plugin/src/main/java/hudson/plugins/swarm/SwarmLauncher.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/SwarmLauncher.java
@@ -1,0 +1,56 @@
+package hudson.plugins.swarm;
+
+import hudson.Extension;
+import hudson.Functions;
+import hudson.model.Descriptor;
+import hudson.model.Slave;
+import hudson.model.TaskListener;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.JNLPLauncher;
+import hudson.slaves.SlaveComputer;
+
+import jenkins.model.Jenkins;
+import jenkins.slaves.DefaultJnlpSlaveReceiver;
+
+import org.jenkinsci.remoting.engine.JnlpConnectionState;
+
+import java.io.IOException;
+
+/**
+ * {@link ComputerLauncher} for Swarm agents. We extend {@link JNLPLauncher} for compatibility with
+ * {@link DefaultJnlpSlaveReceiver#afterProperties(JnlpConnectionState)}.
+ */
+public class SwarmLauncher extends JNLPLauncher {
+
+    public SwarmLauncher() {
+        super(false);
+    }
+
+    @Override
+    public void afterDisconnect(SlaveComputer computer, TaskListener listener) {
+        super.afterDisconnect(computer, listener);
+
+        Slave node = computer.getNode();
+        if (node != null) {
+            try {
+                Jenkins.get().removeNode(node);
+            } catch (IOException e) {
+                Functions.printStackTrace(
+                        e, listener.error("Failed to remove node \"%s\".", node.getNodeName()));
+            }
+        } else {
+            listener.getLogger()
+                    .printf(
+                            "Node for computer \"%s\" appears to have been removed already.%n",
+                            computer);
+        }
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<ComputerLauncher> {
+        @Override
+        public String getDisplayName() {
+            return "Launch Swarm agent";
+        }
+    }
+}

--- a/plugin/src/main/java/hudson/plugins/swarm/SwarmSlave.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/SwarmSlave.java
@@ -1,20 +1,15 @@
 package hudson.plugins.swarm;
 
 import hudson.Extension;
-import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Node;
 import hudson.model.Slave;
-import hudson.model.TaskListener;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.EphemeralNode;
-import hudson.slaves.JNLPLauncher;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
-import hudson.slaves.SlaveComputer;
 import java.io.IOException;
 import java.util.List;
-import jenkins.model.Jenkins;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -66,31 +61,5 @@ public class SwarmSlave extends Slave implements EphemeralNode {
     /**
      * {@link ComputerLauncher} that destroys itself upon a connection termination.
      */
-    private static final JNLPLauncher SELF_CLEANUP_LAUNCHER = new JNLPLauncher() {
-
-        @Override
-        public Descriptor<ComputerLauncher> getDescriptor() {
-            return new Descriptor<ComputerLauncher>() {
-                @Override
-                public String getDisplayName() {
-                    return "Launch swarm slaves";
-                }
-            };
-        }
-
-        @Override
-        public void afterDisconnect(SlaveComputer computer, TaskListener listener) {
-            final Slave node = computer.getNode();
-            if (node != null) {
-                try {
-                    Jenkins.get().removeNode(node);
-                } catch (IOException e) {
-                    e.printStackTrace(listener.error(e.getMessage()));
-                }
-            } else {
-                listener.getLogger().printf("Could not remove node for %s as it appears to have been removed already%n",
-                        computer);
-            }
-        }
-    };
+    private static final ComputerLauncher SELF_CLEANUP_LAUNCHER = new SwarmLauncher();
 }


### PR DESCRIPTION
Minor cleanup of the `SwarmLauncher` class:

- Move `SwarmLauncher` from an anonymous inner class to its own top-level class to make it easier to identify in heap dumps and the like.
- Use `Functions.printStackTrace` to log better stack traces on failure.
- Replace usage of deprecated `JNLPLauncher` constructor with non-deprecated version.