### PR TITLE
More plugin cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Swarm
+# Swarm Plugin
 
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/swarm-plugin/master)](https://ci.jenkins.io/job/Plugins/job/swarm-plugin/job/master/)
 [![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/swarm.svg)](https://plugins.jenkins.io/swarm/)
@@ -6,9 +6,9 @@
 [![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/swarm.svg?color=blue)](https://plugins.jenkins.io/swarm/)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=jenkinsci/swarm-plugin)](https://dependabot.com)
 
-Swarm enables nodes to join a nearby Jenkins master, thereby forming an
-ad-hoc cluster. This plugin makes it easier to scale a Jenkins cluster
-by spinning up and tearing down new nodes.
+The Swarm plugin enables nodes to join a nearby Jenkins master, thereby
+forming an ad-hoc cluster. This plugin makes it easier to scale a Jenkins
+cluster by spinning up and tearing down new nodes.
 
 This plugin consists of two pieces:
 
@@ -42,18 +42,18 @@ settings unexpectedly.
 
 ```
 $ java -jar swarm-client.jar --help
- -deleteExistingClients                 : Deletes any existing slave with the
+ -deleteExistingClients                 : Delete any existing agent with the
                                           same name. (default: false)
- -description VAL                       : Description to be put on the slave
- -disableClientsUniqueId                : Disables client's unique ID.
-                                          (default: false)
- -disableSslVerification                : Disables SSL verification in the
-                                          HttpClient. (default: false)
+ -description VAL                       : Description to be put on the agent.
+ -disableClientsUniqueId                : Disable client's unique ID. (default:
+                                          false)
+ -disableSslVerification                : Disable SSL verification in the HTTP
+                                          client. (default: false)
  -disableWorkDir                        : Disable Remoting working directory
                                           support and run the agent in legacy
                                           mode. (default: false)
  -e (--env)                             : An environment variable to be defined
-                                          on this slave. It is specified as
+                                          on this agent. It is specified as
                                           'key=value'. Multiple variables are
                                           allowed.
  -executors N                           : Number of executors (default: number
@@ -61,8 +61,7 @@ $ java -jar swarm-client.jar --help
  -failIfWorkDirIsMissing                : Fail if the requested Remoting
                                           working directory or internal
                                           directory is missing. (default: false)
- -fsroot FILE                           : Directory where Jenkins places files
-                                          (default: .)
+ -fsroot FILE                           : Remote root directory. (default: .)
  -help (--help)                         : Show the help screen (default: true)
  -internalDir FILE                      : The name of the directory within the
                                           Remoting working directory where
@@ -71,7 +70,7 @@ $ java -jar swarm-client.jar --help
  -jar-cache FILE                        : Cache directory that stores JAR files
                                           sent from the master.
  -labels VAL                            : Whitespace-separated list of labels
-                                          to be assigned for this slave.
+                                          to be assigned for this agent.
                                           Multiple options are allowed.
  -labelsFile VAL                        : File location with space delimited
                                           list of labels.  If the file changes,
@@ -82,13 +81,13 @@ $ java -jar swarm-client.jar --help
                                           seconds. Default is 60 seconds.
                                           (default: 60)
  -mode MODE                             : The mode controlling how Jenkins
-                                          allocates jobs to slaves. Can be
-                                          either 'normal' (utilize this slave
-                                          as much as possible) or 'exclusive'
-                                          (leave this machine for tied jobs
-                                          only). Default is 'normal'. (default:
-                                          normal)
- -name VAL                              : Name of the slave
+                                          allocates jobs to agents. Can be
+                                          either 'normal' (use this node as
+                                          much as possible) or 'exclusive'
+                                          (only build jobs with label
+                                          expressions matching this node).
+                                          Default is 'normal'. (default: normal)
+ -name VAL                              : Name of the agent.
  -noRetryAfterConnected                 : Do not retry if a successful
                                           connection gets closed. (default:
                                           false)
@@ -123,8 +122,8 @@ $ java -jar swarm-client.jar --help
                                           custom fingerprints! Multiple options
                                           are allowed. (default: )
  -t (--toolLocation)                    : A tool location to be defined on this
-                                          slave. It is specified as
-                                          'toolName=location'
+                                          agent. It is specified as
+                                          'toolName=location'.
  -tunnel VAL                            : Connect to the specified host and
                                           port, instead of connecting directly
                                           to Jenkins. Useful when connection to

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>swarm-client</artifactId>
     <groupId>org.jenkins-ci.plugins</groupId>
     <packaging>jar</packaging>
-    <name>Jenkins Swarm Plugin Client</name>
+    <name>Swarm Client</name>
     <version>3.22-SNAPSHOT</version>
 
     <scm>

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -103,25 +103,26 @@ public class Client {
                             .trim();
         }
 
-
-        // Only look up the hostname if we have not already specified
-        // name of the slave. Also in certain cases this lookup might fail.
-        // E.g.
-        // Querying a external DNS server which might not be informed
-        // of a newly created slave from a DHCP server.
-        //
-        // From https://docs.oracle.com/javase/8/docs/api/java/net/InetAddress.html#getCanonicalHostName--
-        //
-        // "Gets the fully qualified domain name for this IP
-        // address. Best effort method, meaning we may not be able to
-        // return the FQDN depending on the underlying system
-        // configuration."
+        /*
+         * Only look up the hostname if we have not already specified name of the agent. In certain
+         * cases this lookup might fail (e.g., querying an external DNS server which might not be
+         * informed of a newly created agent from a DHCP server).
+         *
+         * From https://docs.oracle.com/javase/8/docs/api/java/net/InetAddress.html#getCanonicalHostName--
+         *
+         * "Gets the fully qualified domain name for this IP address. Best effort method, meaning we
+         * may not be able to return the FQDN depending on the underlying system configuration."
+         */
         if (options.name == null) {
             try {
                 client.options.name = InetAddress.getLocalHost().getCanonicalHostName();
             } catch (IOException e) {
-                logger.severe("Failed to lookup the canonical hostname of this slave, please check system settings.");
-                logger.severe("If not possible to resolve please specify a node name using the '-name' option");
+                logger.severe(
+                        "Failed to look up the canonical hostname of this agent. Check the system"
+                                + " DNS settings.");
+                logger.severe(
+                        "If it is not possible to resolve this host, specify a name using the"
+                                + " \"-name\" option.");
                 System.exit(1);
             }
         }
@@ -159,16 +160,16 @@ public class Client {
                                 + swarmClient.getHash());
 
                 /*
-                 * Create a new swarm slave. After this method returns, the value of the name field
+                 * Create a new Swarm agent. After this method returns, the value of the name field
                  * has been set to the name returned by the server, which may or may not be the name
                  * we originally requested.
                  */
-                swarmClient.createSwarmSlave(targetUrl);
+                swarmClient.createSwarmAgent(targetUrl);
 
                 /*
                  * Set up the label file watcher thread. If the label file changes, this thread
                  * takes action to restart the client. Note that this must be done after we create
-                 * the swarm slave, since only then has the server returned the name we must use
+                 * the Swarm agent, since only then has the server returned the name we must use
                  * when doing label operations.
                  */
                 if (options.labelsFile != null) {

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -1,24 +1,29 @@
 package hudson.plugins.swarm;
 
+import org.kohsuke.args4j.Option;
+import org.kohsuke.args4j.spi.MapOptionHandler;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.kohsuke.args4j.Option;
-import org.kohsuke.args4j.spi.MapOptionHandler;
 
 public class Options {
 
-    @Option(name = "-name", usage = "Name of the slave")
+    @Option(name = "-name", usage = "Name of the agent.")
     public String name;
 
-    @Option(name = "-description", usage = "Description to be put on the slave")
+    @Option(name = "-description", usage = "Description to be put on the agent.")
     public String description;
 
-    @Option(name = "-labels", usage = "Whitespace-separated list of labels to be assigned for this slave. Multiple options are allowed.")
+    @Option(
+            name = "-labels",
+            usage =
+                    "Whitespace-separated list of labels to be assigned for this agent. Multiple"
+                            + " options are allowed.")
     public List<String> labels = new ArrayList<>();
 
-    @Option(name = "-fsroot", usage = "Directory where Jenkins places files")
+    @Option(name = "-fsroot", usage = "Remote root directory.")
     public File remoteFsRoot = new File(".");
 
     @Option(name = "-executors", usage = "Number of executors")
@@ -55,7 +60,9 @@ public class Options {
     @Option(name = "-maxRetryInterval", usage = "Max time to wait before retry in seconds. Default is 60 seconds.")
     public int maxRetryInterval = 60;
 
-    @Option(name = "-disableSslVerification", usage = "Disables SSL verification in the HttpClient.")
+    @Option(
+            name = "-disableSslVerification",
+            usage = "Disable SSL verification in the HTTP client.")
     public boolean disableSslVerification;
 
     @Option(name = "-sslFingerprints", usage = "Whitespace-separated list of accepted certificate fingerprints (SHA-256/Hex), "+
@@ -64,34 +71,43 @@ public class Options {
                                                "for custom fingerprints! Multiple options are allowed.")
     public String sslFingerprints = "";
 
-    @Option(name = "-disableClientsUniqueId", usage = "Disables client's unique ID.")
+    @Option(name = "-disableClientsUniqueId", usage = "Disable client's unique ID.")
     public boolean disableClientsUniqueId;
 
-    @Option(name = "-deleteExistingClients", usage = "Deletes any existing slave with the same name.")
+    @Option(
+            name = "-deleteExistingClients",
+            usage = "Delete any existing agent with the same name.")
     public boolean deleteExistingClients;
 
     @Option(
             name = "-mode",
-            usage = "The mode controlling how Jenkins allocates jobs to slaves. Can be either '" + ModeOptionHandler.NORMAL + "' " +
-                    "(utilize this slave as much as possible) or '" + ModeOptionHandler.EXCLUSIVE + "' (leave this machine for tied " +
-                    "jobs only). Default is '" + ModeOptionHandler.NORMAL + "'.",
-            handler = ModeOptionHandler.class
-    )
+            usage =
+                    "The mode controlling how Jenkins allocates jobs to agents. Can be either '"
+                            + ModeOptionHandler.NORMAL
+                            + "' (use this node as much as possible) or '"
+                            + ModeOptionHandler.EXCLUSIVE
+                            + "' (only build jobs with label expressions matching this node)."
+                            + " Default is '"
+                            + ModeOptionHandler.NORMAL
+                            + "'.",
+            handler = ModeOptionHandler.class)
     public String mode = ModeOptionHandler.NORMAL;
 
     @Option(
-            name = "-t", aliases = "--toolLocation",
-            usage = "A tool location to be defined on this slave. It is specified as 'toolName=location'",
-            handler = MapOptionHandler.class
-    )
+            name = "-t",
+            aliases = "--toolLocation",
+            usage =
+                    "A tool location to be defined on this agent. It is specified as"
+                            + " 'toolName=location'.",
+            handler = MapOptionHandler.class)
     public Map<String, String> toolLocations;
 
     @Option(
             name = "-e",
             aliases = "--env",
             usage =
-                    "An environment variable to be defined on this slave. "
-                            + "It is specified as 'key=value'. Multiple variables are allowed.",
+                    "An environment variable to be defined on this agent. It is specified as"
+                            + " 'key=value'. Multiple variables are allowed.",
             handler = MapOptionHandler.class)
     public Map<String, String> environmentVariables;
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -16,7 +16,7 @@
 
     <artifactId>swarm</artifactId>
     <packaging>hpi</packaging>
-    <name>Jenkins Self-Organizing Swarm Plug-in Modules</name>
+    <name>Swarm Plugin</name>
     <url>https://github.com/jenkinsci/swarm-plugin</url>
 
     <developers>

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -4,6 +4,8 @@ import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import hudson.Functions;
 import hudson.Plugin;
 import hudson.Util;
 import hudson.model.Computer;
@@ -11,31 +13,32 @@ import hudson.model.Descriptor.FormException;
 import hudson.model.Node;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.slaves.NodeProperty;
-import hudson.slaves.SlaveComputer;
 import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.tools.ToolLocationNodeProperty;
 import hudson.tools.ToolLocationNodeProperty.ToolLocation;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
-import java.util.UUID;
-import javax.servlet.ServletOutputStream;
+
 import jenkins.model.Jenkins;
+
 import org.apache.commons.lang.ArrayUtils;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.verb.POST;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+
 /**
- * Exposes an entry point to add a new swarm slave.
+ * Exposes an entry point to add a new Swarm agent.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -43,27 +46,22 @@ public class PluginImpl extends Plugin {
 
     private Node getNodeByName(String name, StaplerResponse rsp) throws IOException {
         Jenkins jenkins = Jenkins.get();
+        Node node = jenkins.getNode(name);
 
-        try {
-            Node node = jenkins.getNode(name);
+        if (node == null) {
+            rsp.setStatus(SC_NOT_FOUND);
+            rsp.setContentType("text/plain; UTF-8");
+            rsp.getWriter().printf("Agent \"%s\" does not exist.%n", name);
+            return null;
+        }
 
-            if (node == null) {
-                rsp.setStatus(SC_NOT_FOUND);
-                rsp.setContentType("text/plain; UTF-8");
-                rsp.getWriter().printf("A slave called '%s' does not exist.%n", name);
-                return null;
-            }
-            return node;
-        } catch (NullPointerException ignored) {}
-
-        return null;
+        return node;
     }
 
-    /**
-     * Gets list of labels for slave
-     */
-    public void doGetSlaveLabels(StaplerRequest req, StaplerResponse rsp, @QueryParameter String name)
-                                 throws IOException {
+    /** Get the list of labels for an agent. */
+    public void doGetSlaveLabels(
+            StaplerRequest req, StaplerResponse rsp, @QueryParameter String name)
+            throws IOException {
         Node node = getNodeByName(name, rsp);
         if (node == null) {
             return;
@@ -75,7 +73,8 @@ public class PluginImpl extends Plugin {
     @SuppressFBWarnings(
             value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
             justification = "False positive for try-with-resources in Java 11")
-    private void normalResponse(StaplerRequest req, StaplerResponse rsp, String sLabelList) throws IOException {
+    private void normalResponse(StaplerRequest req, StaplerResponse rsp, String sLabelList)
+            throws IOException {
         rsp.setContentType("text/xml");
 
         try (Writer writer = rsp.getCompressedWriter(req)) {
@@ -83,12 +82,14 @@ public class PluginImpl extends Plugin {
         }
     }
 
-    /**
-     * Adds labels to a slave.
-     */
+    /** Add labels to an agent. */
     @POST
-    public void doAddSlaveLabels(StaplerRequest req, StaplerResponse rsp, @QueryParameter String name,
-                            @QueryParameter String labels)  throws IOException{
+    public void doAddSlaveLabels(
+            StaplerRequest req,
+            StaplerResponse rsp,
+            @QueryParameter String name,
+            @QueryParameter String labels)
+            throws IOException {
         Node node = getNodeByName(name, rsp);
         if (node == null) {
             return;
@@ -96,13 +97,10 @@ public class PluginImpl extends Plugin {
 
         node.checkPermission(Computer.CONFIGURE);
 
-        String sCurrentLabels = node.getLabelString();
-        List<String> lCurrentLabels = Arrays.asList(sCurrentLabels.split("\\s+"));
-        Set<String> hs = new HashSet<>(lCurrentLabels);
-        List<String> lNewLabels = Arrays.asList(labels.split("\\s+"));
-        hs.addAll(lNewLabels);
-        node.setLabelString(setToString(hs));
-        node.getAssignedLabels();
+        LinkedHashSet<String> currentLabels = stringToSet(node.getLabelString());
+        LinkedHashSet<String> labelsToAdd = stringToSet(labels);
+        currentLabels.addAll(labelsToAdd);
+        node.setLabelString(setToString(currentLabels));
 
         normalResponse(req, rsp, node.getLabelString());
     }
@@ -111,12 +109,18 @@ public class PluginImpl extends Plugin {
         return String.join(" ", labels);
     }
 
-    /**
-     * Remove labels from a slave
-     */
+    private static LinkedHashSet<String> stringToSet(String labels) {
+        return new LinkedHashSet<>(Arrays.asList(labels.split("\\s+")));
+    }
+
+    /** Remove labels from an agent. */
     @POST
-    public void doRemoveSlaveLabels(StaplerRequest req, StaplerResponse rsp, @QueryParameter String name,
-                            @QueryParameter String labels) throws IOException {
+    public void doRemoveSlaveLabels(
+            StaplerRequest req,
+            StaplerResponse rsp,
+            @QueryParameter String name,
+            @QueryParameter String labels)
+            throws IOException {
         Node node = getNodeByName(name, rsp);
         if (node == null) {
             return;
@@ -124,102 +128,106 @@ public class PluginImpl extends Plugin {
 
         node.checkPermission(Computer.CONFIGURE);
 
-        String sCurrentLabels = node.getLabelString();
-        List<String> lCurrentLabels = Arrays.asList(sCurrentLabels.split("\\s+"));
-        Set<String> hs = new HashSet<>(lCurrentLabels);
-        List<String> lBadLabels = Arrays.asList(labels.split("\\s+"));
-        hs.removeAll(lBadLabels);
-        node.setLabelString(setToString(hs));
-        node.getAssignedLabels();
+        LinkedHashSet<String> currentLabels = stringToSet(node.getLabelString());
+        LinkedHashSet<String> labelsToRemove = stringToSet(labels);
+        currentLabels.removeAll(labelsToRemove);
+        node.setLabelString(setToString(currentLabels));
+
         normalResponse(req, rsp, node.getLabelString());
     }
 
-    /**
-     * Adds a new swarm slave.
-     */
+    /** Add a new Swarm agent. */
     @POST
-    public void doCreateSlave(StaplerRequest req, StaplerResponse rsp, @QueryParameter String name,
-                              @QueryParameter String description, @QueryParameter int executors,
-                              @QueryParameter String remoteFsRoot, @QueryParameter String labels,
-                              @QueryParameter Node.Mode mode,
-                              @QueryParameter(fixEmpty = true) String hash,
-                              @QueryParameter boolean deleteExistingClients) throws IOException {
-        try {
-            Jenkins jenkins = Jenkins.get();
+    public void doCreateSlave(
+            StaplerRequest req,
+            StaplerResponse rsp,
+            @QueryParameter String name,
+            @QueryParameter(fixEmpty = true) String description,
+            @QueryParameter int executors,
+            @QueryParameter String remoteFsRoot,
+            @QueryParameter String labels,
+            @QueryParameter Node.Mode mode,
+            @QueryParameter(fixEmpty = true) String hash,
+            @QueryParameter boolean deleteExistingClients)
+            throws IOException {
+        Jenkins jenkins = Jenkins.get();
 
-            jenkins.checkPermission(SlaveComputer.CREATE);
+        jenkins.checkPermission(Computer.CREATE);
 
-            List<NodeProperty<Node>> nodeProperties = new ArrayList<>();
+        List<NodeProperty<Node>> nodeProperties = new ArrayList<>();
 
-            String[] toolLocations = req.getParameterValues("toolLocation");
-            if (!ArrayUtils.isEmpty(toolLocations)) {
-                List<ToolLocation> parsedToolLocations = parseToolLocations(toolLocations);
-                nodeProperties.add(new ToolLocationNodeProperty(parsedToolLocations));
-            }
+        String[] toolLocations = req.getParameterValues("toolLocation");
+        if (!ArrayUtils.isEmpty(toolLocations)) {
+            List<ToolLocation> parsedToolLocations = parseToolLocations(toolLocations);
+            nodeProperties.add(new ToolLocationNodeProperty(parsedToolLocations));
+        }
 
-            String[] environmentVariables = req.getParameterValues("environmentVariable");
-            if (!ArrayUtils.isEmpty(environmentVariables)) {
-                List<EnvironmentVariablesNodeProperty.Entry> parsedEnvironmentVariables =
-                        parseEnvironmentVariables(environmentVariables);
-                nodeProperties.add(
-                        new EnvironmentVariablesNodeProperty(parsedEnvironmentVariables));
-            }
+        String[] environmentVariables = req.getParameterValues("environmentVariable");
+        if (!ArrayUtils.isEmpty(environmentVariables)) {
+            List<EnvironmentVariablesNodeProperty.Entry> parsedEnvironmentVariables =
+                    parseEnvironmentVariables(environmentVariables);
+            nodeProperties.add(new EnvironmentVariablesNodeProperty(parsedEnvironmentVariables));
+        }
 
-            if (hash == null && jenkins.getNode(name) != null && !deleteExistingClients) {
-                // this is a legacy client, they won't be able to pick up the new name, so throw them away
-                // perhaps they can find another master to connect to
+        if (hash == null && jenkins.getNode(name) != null && !deleteExistingClients) {
+            /*
+             * This is a legacy client. They won't be able to pick up the new name, so throw them
+             * away. Perhaps they can find another master to connect to.
+             */
+            rsp.setStatus(SC_CONFLICT);
+            rsp.setContentType("text/plain; UTF-8");
+            rsp.getWriter().printf("Agent \"%s\" already exists.%n", name);
+            return;
+        }
+
+        if (hash != null) {
+            /*
+             * Try to make the name unique. Swarm clients are often replicated VMs, and they may
+             * have the same name.
+             */
+            name = name + '-' + hash;
+        }
+
+        // Check for existing connections.
+        Node node = jenkins.getNode(name);
+        if (node != null && !deleteExistingClients) {
+            Computer computer = node.toComputer();
+            if (computer != null && computer.isOnline()) {
+                /*
+                 * This is an existing connection. We'll only cause issues if we trample over an
+                 * online connection.
+                 */
                 rsp.setStatus(SC_CONFLICT);
                 rsp.setContentType("text/plain; UTF-8");
-                rsp.getWriter().printf(
-                        "A slave called '%s' already exists and legacy clients do not support name disambiguation%n",
-                        name);
+                rsp.getWriter().printf("Agent \"%s\" is already created and on-line.%n", name);
                 return;
             }
-            if (hash != null) {
-                // try to make the name unique. Swarm clients are often replicated VMs, and they may have the same name.
-                name = name + '-' + hash;
-            }
-            // check for existing connections
-            Node node = jenkins.getNode(name);
-            if (node != null && !deleteExistingClients) {
-                Computer computer = node.toComputer();
-                if (computer != null && computer.isOnline()) {
-                    // this is an existing connection, we'll only cause issues
-                    // if we trample over an online connection
-                    rsp.setStatus(SC_CONFLICT);
-                    rsp.setContentType("text/plain; UTF-8");
-                    rsp.getWriter().printf("A slave called '%s' is already created and on-line%n", name);
-                    return;
-                }
-            }
+        }
 
-            SwarmSlave slave =
+        try {
+            String nodeDescription = "Swarm agent from " + req.getRemoteHost();
+            if (description != null) {
+                nodeDescription += ": " + description;
+            }
+            SwarmSlave agent =
                     new SwarmSlave(
                             name,
-                            "Swarm slave from "
-                                    + req.getRemoteHost()
-                                    + ((description == null || description.isEmpty())
-                                            ? ""
-                                            : (": " + description)),
+                            nodeDescription,
                             remoteFsRoot,
                             String.valueOf(executors),
                             mode,
                             "swarm " + Util.fixNull(labels),
                             nodeProperties);
+            jenkins.addNode(agent);
 
-            jenkins.addNode(slave);
             rsp.setContentType("text/plain; charset=iso-8859-1");
-            Properties props = new Properties();
-            props.put("name", name);
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            props.store(bos, "");
-            byte[] response = bos.toByteArray();
-            rsp.setContentLength(response.length);
-            ServletOutputStream outputStream = rsp.getOutputStream();
-            outputStream.write(response);
-            outputStream.flush();
+            try (OutputStream outputStream = rsp.getCompressedOutputStream(req)) {
+                Properties props = new Properties();
+                props.put("name", name);
+                props.store(outputStream, "");
+            }
         } catch (FormException e) {
-            e.printStackTrace();
+            Functions.printStackTrace(e, System.err);
         }
     }
 
@@ -228,9 +236,10 @@ public class PluginImpl extends Plugin {
 
         for (String toolLocKeyValue : toolLocations) {
             boolean found = false;
-            // Limit the split on only the first occurrence
-            // of ':', so that the tool location path can
-            // contain ':' characters.
+            /*
+             * Limit the split on only the first occurrence of ':' so that the tool location path
+             * can contain ':' characters.
+             */
             String[] toolLoc = toolLocKeyValue.split(":", 2);
 
             for (ToolDescriptor<?> desc : ToolInstallation.all()) {
@@ -240,14 +249,15 @@ public class PluginImpl extends Plugin {
 
                         String location = toolLoc[1];
 
-                        ToolLocationNodeProperty.ToolLocation toolLocation = new ToolLocationNodeProperty
-                                .ToolLocation(desc, inst.getName(), location);
+                        ToolLocationNodeProperty.ToolLocation toolLocation =
+                                new ToolLocationNodeProperty.ToolLocation(
+                                        desc, inst.getName(), location);
                         result.add(toolLocation);
                     }
                 }
             }
 
-            // don't fail silently, inform the user what tool is missing
+            // Don't fail silently; rather, inform the user what tool is missing.
             if (!found) {
                 throw new RuntimeException("No tool '" + toolLoc[0] + "' is defined on Jenkins.");
             }
@@ -261,8 +271,10 @@ public class PluginImpl extends Plugin {
         List<EnvironmentVariablesNodeProperty.Entry> result = new ArrayList<>();
 
         for (String environmentVariable : environmentVariables) {
-            // Limit the split on only the first occurrence of ':' so that the value can contain ':'
-            // characters.
+            /*
+             * Limit the split on only the first occurrence of ':' so that the value can contain ':'
+             * characters.
+             */
             String[] keyValue = environmentVariable.split(":", 2);
             EnvironmentVariablesNodeProperty.Entry var =
                     new EnvironmentVariablesNodeProperty.Entry(keyValue[0], keyValue[1]);
@@ -286,11 +298,14 @@ public class PluginImpl extends Plugin {
             justification = "False positive for try-with-resources in Java 11")
     public void doSlaveInfo(StaplerRequest req, StaplerResponse rsp) throws IOException {
         Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(SlaveComputer.CREATE);
+        jenkins.checkPermission(Computer.CREATE);
 
         rsp.setContentType("text/xml");
         try (Writer writer = rsp.getCompressedWriter(req)) {
-            writer.write("<slaveInfo><swarmSecret>" + UUID.randomUUID().toString() + "</swarmSecret></slaveInfo>");
+            writer.write(
+                    "<slaveInfo><swarmSecret>"
+                            + UUID.randomUUID().toString()
+                            + "</swarmSecret></slaveInfo>");
         }
     }
 }

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -138,6 +138,9 @@ public class PluginImpl extends Plugin {
 
     /** Add a new Swarm agent. */
     @POST
+    @SuppressFBWarnings(
+            value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+            justification = "False positive for try-with-resources in Java 11")
     public void doCreateSlave(
             StaplerRequest req,
             StaplerResponse rsp,

--- a/plugin/src/main/java/hudson/plugins/swarm/SwarmSlave.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/SwarmSlave.java
@@ -8,14 +8,17 @@ import hudson.slaves.ComputerLauncher;
 import hudson.slaves.EphemeralNode;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
 import java.io.IOException;
 import java.util.List;
-import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * {@link Slave} created by ad-hoc local systems.
- * <p>
- * This acts like a JNLP slave, except when the client disconnects, the slave will be deleted.
+ *
+ * <p>This acts like an inbound agent, except when the client disconnects, the agent will be
+ * deleted.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -46,7 +49,7 @@ public class SwarmSlave extends Slave implements EphemeralNode {
 
         @Override
         public String getDisplayName() {
-            return "Swarm Slave";
+            return "Swarm agent";
         }
 
         /**

--- a/plugin/src/main/resources/hudson/plugins/swarm/SwarmSlave/configure-entries.jelly
+++ b/plugin/src/main/resources/hudson/plugins/swarm/SwarmSlave/configure-entries.jelly
@@ -32,10 +32,10 @@ THE SOFTWARE.
   </f:entry>
 
   <f:entry title="${%# of executors}" field="numExecutors">
-    <f:textbox />
+    <f:number clazz="positive-number-required" min="1" step="1" default="1"/>
   </f:entry>
 
-  <f:entry title="${%Remote FS root}" field="remoteFS">
+  <f:entry title="${%Remote root directory}" field="remoteFS">
     <f:textbox />
   </f:entry>
 
@@ -45,5 +45,5 @@ THE SOFTWARE.
 
   <f:slave-mode name="mode" node="${it}" />
 
-  <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}" field="nodeProperties" />
+  <f:descriptorList title="${%Node Properties}" descriptors="${descriptor.nodePropertyDescriptors(it)}" field="nodeProperties" />
 </j:jelly>

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -197,10 +197,7 @@ public class SwarmClientIntegrationTest {
 
         // Try to start a second and ensure it fails to run.
         startFailingSwarmClient(
-                j.getURL(),
-                "agent_fail",
-                "-pidFile",
-                pidFile.toAbsolutePath().toString());
+                j.getURL(), "agent_fail", "-pidFile", pidFile.toAbsolutePath().toString());
 
         // Now ensure that the original process is still OK and so is its PID file.
         assertNotNull("Original client should still be running", os.getProcess(firstClientPid));
@@ -312,7 +309,7 @@ public class SwarmClientIntegrationTest {
         Node node = swarmClientRule.createSwarmClient();
         assertTrue(
                 node.getNodeDescription(),
-                Pattern.matches("Swarm slave from ([a-zA-Z_0-9-.]+)", node.getNodeDescription()));
+                Pattern.matches("Swarm agent from ([a-zA-Z_0-9-.]+)", node.getNodeDescription()));
     }
 
     @Test
@@ -321,7 +318,7 @@ public class SwarmClientIntegrationTest {
         assertTrue(
                 node.getNodeDescription(),
                 Pattern.matches(
-                        "Swarm slave from ([a-zA-Z_0-9-.]+): foobar", node.getNodeDescription()));
+                        "Swarm agent from ([a-zA-Z_0-9-.]+): foobar", node.getNodeDescription()));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <artifactId>swarm-plugin</artifactId>
     <packaging>pom</packaging>
-    <name>Jenkins Self-Organizing Swarm Plug-in</name>
+    <name>Swarm Plugin Parent POM</name>
     <version>3.22-SNAPSHOT</version>
 
     <properties>


### PR DESCRIPTION
Grab bag of various internal cleanup:

- Use more consistent naming for customer-visible artifacts
- Simply logic for backend API endpoints
- Show HTTP response on CSRF failure
- Minor reformatting using `google-java-format`