### PR TITLE
Cleanup grab bag

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -29,7 +29,7 @@ public class Client {
 
     private final Options options;
 
-    //TODO: Cleanup the encoding issue
+    // TODO: Cleanup the encoding issue
     public static void main(String... args) throws InterruptedException, IOException {
         Options options = new Options();
         Client client = new Client(options);
@@ -49,9 +49,11 @@ public class Client {
         }
 
         if (options.pidFile != null) {
-            // This will return a string like 12345@hostname, so we need to do some string manipulation
-            // to get the actual process identifier.
-            // In Java 9, this can be replaced with: ProcessHandle.current().getPid();
+            /*
+             * This will return a string like 12345@hostname, so we need to do some string
+             * manipulation to get the actual process identifier. In Java 9, this can be replaced
+             * with: ProcessHandle.current().getPid();
+             */
             String pidName = ManagementFactory.getRuntimeMXBean().getName();
             String[] pidNameParts = pidName.split("@");
             String pid = pidNameParts[0];
@@ -69,7 +71,9 @@ public class Client {
                     if (oldProcess != null) {
                         logger.severe(
                                 String.format(
-                                        "Refusing to start because PID file '%s' already exists and the previous process %d (%s) is still running.",
+                                        "Refusing to start because PID file '%s' already exists"
+                                                + " and the previous process %d (%s) is still"
+                                                + " running.",
                                         pidFile.getAbsolutePath(),
                                         oldPid,
                                         oldProcess.getCommandLine()));
@@ -77,7 +81,8 @@ public class Client {
                     } else {
                         logger.fine(
                                 String.format(
-                                        "Ignoring PID file '%s' because the previous process %d is no longer running.",
+                                        "Ignoring PID file '%s' because the previous process %d is"
+                                                + " no longer running.",
                                         pidFile.getAbsolutePath(), oldPid));
                     }
                 }
@@ -129,7 +134,9 @@ public class Client {
         }
 
         SwarmClient swarmClient = new SwarmClient(options);
-        client.run(swarmClient, args); // pass the command line arguments along so that the LabelFileWatcher thread can have them
+
+        // Pass the command line arguments along so that the LabelFileWatcher thread can have them.
+        client.run(swarmClient, args);
     }
 
     public Client(Options options) {
@@ -182,7 +189,9 @@ public class Client {
                 logger.log(Level.SEVERE, "An error occurred", e);
             }
 
-            int waitTime = options.retryBackOffStrategy.waitForRetry(retry++, options.retryInterval, options.maxRetryInterval);
+            int waitTime =
+                    options.retryBackOffStrategy.waitForRetry(
+                            retry++, options.retryInterval, options.maxRetryInterval);
             if (options.retry >= 0) {
                 if (retry >= options.retry) {
                     logger.severe("Retry limit reached, exiting...");

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -20,6 +20,7 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -180,7 +181,12 @@ public class Client {
                     labelFileWatcherThread.start();
                 }
 
-                swarmClient.connect(masterUrl);
+                /*
+                 * Note that any instances of InterruptedException or RuntimeException thrown
+                 * internally by the next two lines get wrapped in RetryException.
+                 */
+                List<String> jnlpArgs = swarmClient.getJnlpArgs(masterUrl);
+                swarmClient.connect(jnlpArgs, masterUrl);
                 if (options.noRetryAfterConnected) {
                     logger.warning("Connection closed, exiting...");
                     swarmClient.exitWithStatus(0);

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -12,6 +12,7 @@ import oshi.software.os.OSProcess;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.URL;
@@ -84,9 +85,8 @@ public class Client {
             pidFile.deleteOnExit();
             try {
                 Files.write(pidFile.toPath(), pid.getBytes(StandardCharsets.UTF_8));
-            } catch (IOException exception) {
-                logger.severe("Failed writing PID file: " + options.pidFile);
-                System.exit(1);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed writing PID file: " + options.pidFile, e);
             }
         }
 
@@ -124,7 +124,7 @@ public class Client {
                 logger.severe(
                         "If it is not possible to resolve this host, specify a name using the"
                                 + " \"-name\" option.");
-                System.exit(1);
+                throw new UncheckedIOException(e);
             }
         }
 
@@ -180,7 +180,6 @@ public class Client {
                 }
             } catch (IOException | RetryException e) {
                 logger.log(Level.SEVERE, "An error occurred", e);
-                e.printStackTrace();
             }
 
             int waitTime = options.retryBackOffStrategy.waitForRetry(retry++, options.retryInterval, options.maxRetryInterval);

--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -39,7 +39,7 @@ public class LabelFileWatcher implements Runnable {
     private final Options options;
     private final String name;
     private String labels;
-    private String[] args;
+    private final String[] args;
     private final URL masterUrl;
 
     public LabelFileWatcher(URL masterUrl, Options options, String name, String... args)

--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -156,14 +156,14 @@ public class LabelFileWatcher implements Runnable {
     private void hardLabelUpdate() throws IOException {
         logger.config("NOTICE: " + options.labelsFile + " has changed.  Hard node restart attempt initiated.");
         isRunning = false;
-        final String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
         try {
-            final File currentJar = new File(LabelFileWatcher.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            File currentJar = new File(LabelFileWatcher.class.getProtectionDomain().getCodeSource().getLocation().toURI());
             if (!currentJar.getName().endsWith(".jar")) {
                 throw new URISyntaxException(currentJar.getName(), "Doesn't end in .jar");
             } else {
                 // invoke the restart
-                final ArrayList<String> command = new ArrayList<>();
+                ArrayList<String> command = new ArrayList<>();
                 command.add(javaBin);
                 if (System.getProperty("java.util.logging.config.file") == null) {
                     logger.warning("NOTE:  You do not have a -Djava.util.logging.config.file specified, but your labels file has changed.  You will lose logging for the new client instance. Although the client will continue to work, you will have no logging.");
@@ -176,7 +176,7 @@ public class LabelFileWatcher implements Runnable {
                 String sCommandString = Arrays.toString(command.toArray());
                 sCommandString = sCommandString.replaceAll("\n", "").replaceAll("\r", "").replaceAll(",", "");
                 logger.config("Invoking: " + sCommandString);
-                final ProcessBuilder builder = new ProcessBuilder(command);
+                ProcessBuilder builder = new ProcessBuilder(command);
                 builder.start();
                 logger.config("New node instance started, ignore subsequent warning.");
             }

--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -44,11 +44,17 @@ public class LabelFileWatcher implements Runnable {
 
     public LabelFileWatcher(URL masterUrl, Options options, String name, String... args)
             throws IOException {
-        logger.config("LabelFileWatcher() constructed with: " + options.labelsFile + " and " + StringUtils.join(args));
+        logger.config(
+                "LabelFileWatcher() constructed with: "
+                        + options.labelsFile
+                        + " and "
+                        + StringUtils.join(args));
         this.masterUrl = masterUrl;
         this.options = options;
         this.name = name;
-        this.labels = new String(Files.readAllBytes(Paths.get(options.labelsFile)), StandardCharsets.UTF_8);
+        this.labels =
+                new String(
+                        Files.readAllBytes(Paths.get(options.labelsFile)), StandardCharsets.UTF_8);
         this.args = args;
         logger.config("Labels loaded: " + labels);
     }
@@ -60,7 +66,11 @@ public class LabelFileWatcher implements Runnable {
         // 1. get labels from master
         // 2. issue remove command for all old labels
         // 3. issue update commands for new labels
-        logger.log(Level.CONFIG, "NOTICE: " + options.labelsFile + " has changed.  Attempting soft label update (no node restart)");
+        logger.log(
+                Level.CONFIG,
+                "NOTICE: "
+                        + options.labelsFile
+                        + " has changed.  Attempting soft label update (no node restart)");
         CloseableHttpClient client = SwarmClient.createHttpClient(options);
         HttpClientContext context = SwarmClient.createHttpClientContext(options, masterUrl);
 
@@ -154,11 +164,21 @@ public class LabelFileWatcher implements Runnable {
     }
 
     private void hardLabelUpdate() throws IOException {
-        logger.config("NOTICE: " + options.labelsFile + " has changed.  Hard node restart attempt initiated.");
+        logger.config(
+                "NOTICE: "
+                        + options.labelsFile
+                        + " has changed.  Hard node restart attempt initiated.");
         isRunning = false;
-        String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        String javaBin =
+                System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
         try {
-            File currentJar = new File(LabelFileWatcher.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+            File currentJar =
+                    new File(
+                            LabelFileWatcher.class
+                                    .getProtectionDomain()
+                                    .getCodeSource()
+                                    .getLocation()
+                                    .toURI());
             if (!currentJar.getName().endsWith(".jar")) {
                 throw new URISyntaxException(currentJar.getName(), "Doesn't end in .jar");
             } else {
@@ -166,22 +186,36 @@ public class LabelFileWatcher implements Runnable {
                 ArrayList<String> command = new ArrayList<>();
                 command.add(javaBin);
                 if (System.getProperty("java.util.logging.config.file") == null) {
-                    logger.warning("NOTE:  You do not have a -Djava.util.logging.config.file specified, but your labels file has changed.  You will lose logging for the new client instance. Although the client will continue to work, you will have no logging.");
+                    logger.warning(
+                            "NOTE:  You do not have a -Djava.util.logging.config.file specified,"
+                                + " but your labels file has changed.  You will lose logging for"
+                                + " the new client instance. Although the client will continue to"
+                                + " work, you will have no logging.");
                 } else {
-                    command.add("-Djava.util.logging.config.file=" + System.getProperty("java.util.logging.config.file"));
+                    command.add(
+                            "-Djava.util.logging.config.file="
+                                    + System.getProperty("java.util.logging.config.file"));
                 }
                 command.add("-jar");
                 command.add(currentJar.getPath());
                 Collections.addAll(command, args);
                 String sCommandString = Arrays.toString(command.toArray());
-                sCommandString = sCommandString.replaceAll("\n", "").replaceAll("\r", "").replaceAll(",", "");
+                sCommandString =
+                        sCommandString
+                                .replaceAll("\n", "")
+                                .replaceAll("\r", "")
+                                .replaceAll(",", "");
                 logger.config("Invoking: " + sCommandString);
                 ProcessBuilder builder = new ProcessBuilder(command);
                 builder.start();
                 logger.config("New node instance started, ignore subsequent warning.");
             }
         } catch (URISyntaxException e) {
-            logger.log(Level.SEVERE, "ERROR: LabelFileWatcher unable to determine current running jar. Node failure. URISyntaxException.", e);
+            logger.log(
+                    Level.SEVERE,
+                    "ERROR: LabelFileWatcher unable to determine current running jar. Node"
+                            + " failure. URISyntaxException.",
+                    e);
         }
     }
 
@@ -207,12 +241,16 @@ public class LabelFileWatcher implements Runnable {
             try {
                 sTempLabels =
                         new String(
-                                Files.readAllBytes(Paths.get(options.labelsFile)), StandardCharsets.UTF_8);
+                                Files.readAllBytes(Paths.get(options.labelsFile)),
+                                StandardCharsets.UTF_8);
                 if (sTempLabels.equalsIgnoreCase(labels)) {
-                    logger.log(Level.FINEST, "Nothing to do. " + options.labelsFile + " has not changed.");
+                    logger.log(
+                            Level.FINEST,
+                            "Nothing to do. " + options.labelsFile + " has not changed.");
                 } else {
                     try {
-                        // try to do the "soft" form of label updating (manipulating the labels through the plugin APIs
+                        // try to do the "soft" form of label updating (manipulating the labels
+                        // through the plugin APIs
                         softLabelUpdate(sTempLabels);
                         labels =
                                 new String(
@@ -220,16 +258,27 @@ public class LabelFileWatcher implements Runnable {
                                         StandardCharsets.UTF_8);
                     } catch (SoftLabelUpdateException e) {
                         // if we're unable to
-                        logger.log(Level.WARNING, "WARNING: Normal process, soft label update failed. " + e.getLocalizedMessage() + ", forcing swarm client reboot.  This can be disruptive to Jenkins jobs.  Check your swarm client log files to see why this is happening.");
+                        logger.log(
+                                Level.WARNING,
+                                "WARNING: Normal process, soft label update failed. "
+                                        + e.getLocalizedMessage()
+                                        + ", forcing Swarm client restart. This can be disruptive"
+                                        + " to Jenkins jobs. Check your Swarm client log files to"
+                                        + " see why this is happening.");
                         hardLabelUpdate();
                     }
                 }
             } catch (IOException e) {
-                logger.log(Level.WARNING, "WARNING: unable to read " + options.labelsFile + ", node may not be reporting proper labels to master.", e);
+                logger.log(
+                        Level.WARNING,
+                        "WARNING: unable to read "
+                                + options.labelsFile
+                                + ", node may not be reporting proper labels to master.",
+                        e);
             }
         }
 
-        logger.warning("LabelFileWatcher no longer running. Shutting down this instance of Swarm Client.");
+        logger.warning("LabelFileWatcher no longer running. Shutting down this Swarm client.");
         System.exit(0);
     }
 }

--- a/client/src/main/java/hudson/plugins/swarm/ModeOptionHandler.java
+++ b/client/src/main/java/hudson/plugins/swarm/ModeOptionHandler.java
@@ -20,13 +20,13 @@ public class ModeOptionHandler extends OneArgumentOptionHandler<String> {
 
     private static final List<String> ACCEPTABLE_VALUES = Arrays.asList(NORMAL, EXCLUSIVE);
 
-    public ModeOptionHandler(final CmdLineParser parser, final OptionDef option, final Setter<? super String> setter) {
+    public ModeOptionHandler(CmdLineParser parser, OptionDef option, Setter<? super String> setter) {
         super(parser, option, setter);
     }
 
     @Override
-    public String parse(final String argument) throws NumberFormatException, CmdLineException {
-        final int index = ACCEPTABLE_VALUES.indexOf(argument);
+    public String parse(String argument) throws NumberFormatException, CmdLineException {
+        int index = ACCEPTABLE_VALUES.indexOf(argument);
         if (index == -1) {
             throw new CmdLineException(owner, "Invalid mode", null);
         }

--- a/client/src/main/java/hudson/plugins/swarm/ModeOptionHandler.java
+++ b/client/src/main/java/hudson/plugins/swarm/ModeOptionHandler.java
@@ -1,12 +1,13 @@
 package hudson.plugins.swarm;
 
-import java.util.Arrays;
-import java.util.List;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.OptionDef;
 import org.kohsuke.args4j.spi.OneArgumentOptionHandler;
 import org.kohsuke.args4j.spi.Setter;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Parses possible node modes: can be either 'normal' or 'exclusive'.
@@ -20,7 +21,8 @@ public class ModeOptionHandler extends OneArgumentOptionHandler<String> {
 
     private static final List<String> ACCEPTABLE_VALUES = Arrays.asList(NORMAL, EXCLUSIVE);
 
-    public ModeOptionHandler(CmdLineParser parser, OptionDef option, Setter<? super String> setter) {
+    public ModeOptionHandler(
+            CmdLineParser parser, OptionDef option, Setter<? super String> setter) {
         super(parser, option, setter);
     }
 
@@ -38,5 +40,4 @@ public class ModeOptionHandler extends OneArgumentOptionHandler<String> {
     public String getDefaultMetaVariable() {
         return "MODE";
     }
-
 }

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -29,12 +29,19 @@ public class Options {
     @Option(name = "-executors", usage = "Number of executors")
     public int executors = Runtime.getRuntime().availableProcessors();
 
-    @Option(name = "-master", usage = "The complete target Jenkins URL like 'http://server:8080/jenkins/'.", required = true)
+    @Option(
+            name = "-master",
+            usage = "The complete target Jenkins URL like 'http://server:8080/jenkins/'.",
+            required = true)
     public String master;
 
-    @Option(name = "-tunnel", usage = "Connect to the specified host and port, instead of connecting directly to Jenkins. " +
-                    "Useful when connection to Jenkins needs to be tunneled. Can be also HOST: or :PORT, " +
-                    "in which case the missing portion will be auto-configured like the default behavior")
+    @Option(
+            name = "-tunnel",
+            usage =
+                    "Connect to the specified host and port, instead of connecting directly to"
+                        + " Jenkins. Useful when connection to Jenkins needs to be tunneled. Can"
+                        + " be also HOST: or :PORT, in which case the missing portion will be"
+                        + " auto-configured like the default behavior")
     public String tunnel;
 
     @Option(
@@ -43,27 +50,34 @@ public class Options {
             forbids = "-tunnel")
     public boolean webSocket;
 
-    @Option(name = "-noRetryAfterConnected", usage = "Do not retry if a successful connection gets closed.")
+    @Option(
+            name = "-noRetryAfterConnected",
+            usage = "Do not retry if a successful connection gets closed.")
     public boolean noRetryAfterConnected;
 
-    @Option(name = "-retry", usage = "Number of retries before giving up. Unlimited if not specified.")
+    @Option(
+            name = "-retry",
+            usage = "Number of retries before giving up. Unlimited if not specified.")
     public int retry = -1;
 
     @Option(
             name = "-retryBackOffStrategy",
-            usage = "The mode controlling retry wait time. Can be either " +
-                    "'none' (use same interval between retries) " +
-                    "or 'linear' (increase wait time before each retry up to maxRetryInterval) " +
-                    "or 'exponential' (double wait interval on each retry up to maxRetryInterval). " +
-                    "Default is 'none'.",
-            handler = RetryBackOffStrategyOptionHandler.class
-    )
+            usage =
+                    "The mode controlling retry wait time. Can be either 'none' (use same interval"
+                        + " between retries) or 'linear' (increase wait time before each retry up"
+                        + " to maxRetryInterval) or 'exponential' (double wait interval on each"
+                        + " retry up to maxRetryInterval). Default is 'none'.",
+            handler = RetryBackOffStrategyOptionHandler.class)
     public RetryBackOffStrategy retryBackOffStrategy = RetryBackOffStrategy.NONE;
 
-    @Option(name = "-retryInterval", usage = "Time to wait before retry in seconds. Default is 10 seconds.")
+    @Option(
+            name = "-retryInterval",
+            usage = "Time to wait before retry in seconds. Default is 10 seconds.")
     public int retryInterval = 10;
 
-    @Option(name = "-maxRetryInterval", usage = "Max time to wait before retry in seconds. Default is 60 seconds.")
+    @Option(
+            name = "-maxRetryInterval",
+            usage = "Max time to wait before retry in seconds. Default is 60 seconds.")
     public int maxRetryInterval = 60;
 
     @Option(
@@ -71,10 +85,13 @@ public class Options {
             usage = "Disable SSL verification in the HTTP client.")
     public boolean disableSslVerification;
 
-    @Option(name = "-sslFingerprints", usage = "Whitespace-separated list of accepted certificate fingerprints (SHA-256/Hex), "+
-                                               "otherwise system truststore will be used. " +
-                                               "No revocation, expiration or not yet valid check will be performed " +
-                                               "for custom fingerprints! Multiple options are allowed.")
+    @Option(
+            name = "-sslFingerprints",
+            usage =
+                    "Whitespace-separated list of accepted certificate fingerprints (SHA-256/Hex), "
+                            + "otherwise system truststore will be used. "
+                            + "No revocation, expiration or not yet valid check will be performed "
+                            + "for custom fingerprints! Multiple options are allowed.")
     public String sslFingerprints = "";
 
     @Option(name = "-disableClientsUniqueId", usage = "Disable client's unique ID.")
@@ -140,7 +157,11 @@ public class Options {
             usage = "File containing the Jenkins user API token or password.")
     public String passwordFile;
 
-    @Option(name = "-labelsFile", usage = "File location with space delimited list of labels.  If the file changes, the client is restarted.")
+    @Option(
+            name = "-labelsFile",
+            usage =
+                    "File location with space delimited list of labels.  If the file changes, the"
+                            + " client is restarted.")
     public String labelsFile;
 
     @Option(
@@ -165,7 +186,8 @@ public class Options {
     @Option(
             name = "-internalDir",
             usage =
-                    "The name of the directory within the Remoting working directory where files internal to Remoting will be stored.",
+                    "The name of the directory within the Remoting working directory where files"
+                            + " internal to Remoting will be stored.",
             forbids = "-disableWorkDir")
     public File internalDir;
 
@@ -177,7 +199,8 @@ public class Options {
     @Option(
             name = "-failIfWorkDirIsMissing",
             usage =
-                    "Fail if the requested Remoting working directory or internal directory is missing.",
+                    "Fail if the requested Remoting working directory or internal directory is"
+                            + " missing.",
             forbids = "-disableWorkDir")
     public boolean failIfWorkDirIsMissing = false;
 }

--- a/client/src/main/java/hudson/plugins/swarm/RetryBackOffStrategy.java
+++ b/client/src/main/java/hudson/plugins/swarm/RetryBackOffStrategy.java
@@ -1,7 +1,6 @@
 package hudson.plugins.swarm;
 
 public enum RetryBackOffStrategy {
-
     NONE {
         @Override
         public int waitForRetry(int retry, int interval, int maxTime) {
@@ -24,5 +23,4 @@ public enum RetryBackOffStrategy {
     };
 
     abstract int waitForRetry(int retry, int interval, int maxTime);
-
 }

--- a/client/src/main/java/hudson/plugins/swarm/RetryBackOffStrategyOptionHandler.java
+++ b/client/src/main/java/hudson/plugins/swarm/RetryBackOffStrategyOptionHandler.java
@@ -7,7 +7,8 @@ import org.kohsuke.args4j.spi.Setter;
 
 public class RetryBackOffStrategyOptionHandler extends EnumOptionHandler<RetryBackOffStrategy> {
 
-    public RetryBackOffStrategyOptionHandler(CmdLineParser parser, OptionDef option, Setter<? super RetryBackOffStrategy> setter) {
+    public RetryBackOffStrategyOptionHandler(
+            CmdLineParser parser, OptionDef option, Setter<? super RetryBackOffStrategy> setter) {
         super(parser, option, setter, RetryBackOffStrategy.class);
     }
 
@@ -15,5 +16,4 @@ public class RetryBackOffStrategyOptionHandler extends EnumOptionHandler<RetryBa
     public String getDefaultMetaVariable() {
         return "RETRY_BACK_OFF_STRATEGY";
     }
-
 }

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -76,7 +76,6 @@ public class SwarmClient {
     private final String hash;
     private String name;
 
-    @SuppressFBWarnings("DM_EXIT")
     public SwarmClient(Options options) {
         this.options = options;
         if (!options.disableClientsUniqueId) {

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -93,7 +93,11 @@ public class SwarmClient {
                                 StandardCharsets.UTF_8);
                 options.labels.addAll(Arrays.asList(labels.split(" ")));
                 logger.info("Labels found in file: " + labels);
-                logger.info("Effective label list: " + Arrays.toString(options.labels.toArray()).replaceAll("\n", "").replaceAll("\r", ""));
+                logger.info(
+                        "Effective label list: "
+                                + Arrays.toString(options.labels.toArray())
+                                        .replaceAll("\n", "")
+                                        .replaceAll("\r", ""));
             } catch (IOException e) {
                 throw new UncheckedIOException(
                         "Problem reading labels from file " + options.labelsFile, e);
@@ -337,7 +341,10 @@ public class SwarmClient {
         StringBuilder toolLocationBuilder = new StringBuilder();
         if (options.toolLocations != null) {
             for (Entry<String, String> toolLocation : options.toolLocations.entrySet()) {
-                toolLocationBuilder.append(param("toolLocation", toolLocation.getKey() + ":" + toolLocation.getValue()));
+                toolLocationBuilder.append(
+                        param(
+                                "toolLocation",
+                                toolLocation.getKey() + ":" + toolLocation.getValue()));
             }
         }
 
@@ -509,7 +516,8 @@ public class SwarmClient {
         return URLEncoder.encode(value, "UTF-8");
     }
 
-    private static synchronized String param(String name, String value) throws UnsupportedEncodingException {
+    private static synchronized String param(String name, String value)
+            throws UnsupportedEncodingException {
         logger.finer("param() invoked");
 
         if (value == null) {

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -333,7 +333,7 @@ public class SwarmClient {
     @SuppressFBWarnings(
             value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
             justification = "False positive for try-with-resources in Java 11")
-    protected void createSwarmAgent(URL masterUrl) throws IOException, RetryException {
+    void createSwarmAgent(URL masterUrl) throws IOException, RetryException {
         logger.fine("createSwarmAgent() invoked");
 
         CloseableHttpClient client = createHttpClient(options);
@@ -455,7 +455,7 @@ public class SwarmClient {
     @SuppressFBWarnings(
             value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
             justification = "False positive for try-with-resources in Java 11")
-    protected static synchronized void postLabelRemove(
+    static synchronized void postLabelRemove(
             String name,
             String labels,
             CloseableHttpClient client,
@@ -491,7 +491,7 @@ public class SwarmClient {
     @SuppressFBWarnings(
             value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
             justification = "False positive for try-with-resources in Java 11")
-    protected static synchronized void postLabelAppend(
+    static synchronized void postLabelAppend(
             String name,
             String labels,
             CloseableHttpClient client,
@@ -544,7 +544,7 @@ public class SwarmClient {
     @SuppressFBWarnings(
             value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
             justification = "False positive for try-with-resources in Java 11")
-    protected VersionNumber getJenkinsVersion(
+    VersionNumber getJenkinsVersion(
             CloseableHttpClient client, HttpClientContext context, URL masterUrl)
             throws IOException, RetryException {
         logger.fine("getJenkinsVersion() invoked");
@@ -643,7 +643,7 @@ public class SwarmClient {
         Thread.sleep(waitTime * 1000);
     }
 
-    protected static class DefaultTrustManager implements X509TrustManager {
+    private static class DefaultTrustManager implements X509TrustManager {
 
         final List<String> allowedFingerprints = new ArrayList<>();
 

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -95,9 +95,8 @@ public class SwarmClient {
                 logger.info("Labels found in file: " + labels);
                 logger.info("Effective label list: " + Arrays.toString(options.labels.toArray()).replaceAll("\n", "").replaceAll("\r", ""));
             } catch (IOException e) {
-                logger.log(Level.SEVERE, "Problem reading labels from file " + options.labelsFile, e);
-                e.printStackTrace();
-                System.exit(1);
+                throw new UncheckedIOException(
+                        "Problem reading labels from file " + options.labelsFile, e);
             }
         }
     }
@@ -233,11 +232,8 @@ public class SwarmClient {
                         new TrustManager[] {new DefaultTrustManager(trusted)},
                         new SecureRandom());
                 SSLContext.setDefault(ctx);
-            } catch (KeyManagementException e) {
-                logger.log(Level.SEVERE, "KeyManagementException occurred", e);
-                throw new RuntimeException(e);
-            } catch (NoSuchAlgorithmException e) {
-                logger.log(Level.SEVERE, "NoSuchAlgorithmException occurred", e);
+            } catch (KeyManagementException | NoSuchAlgorithmException e) {
+                logger.log(Level.SEVERE, "An error occurred", e);
                 throw new RuntimeException(e);
             }
         }

--- a/client/src/main/java/hudson/plugins/swarm/XmlUtils.java
+++ b/client/src/main/java/hudson/plugins/swarm/XmlUtils.java
@@ -1,19 +1,22 @@
 package hudson.plugins.swarm;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
-import edu.umd.cs.findbugs.annotations.NonNull;
+
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.w3c.dom.Document;
-import org.xml.sax.SAXException;
 
 @Restricted(NoExternalUse.class)
 public final class XmlUtils {

--- a/client/src/test/java/hudson/plugins/swarm/ClientTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/ClientTest.java
@@ -70,9 +70,8 @@ public class ClientTest {
 
     private void runAndVerify(Options options, String expectedResult) {
         SwarmClient swarmClient = new DummySwarmClient(options);
-        Client client = new Client(options);
         IllegalStateException thrown =
-                assertThrows(IllegalStateException.class, () -> client.run(swarmClient));
+                assertThrows(IllegalStateException.class, () -> Client.run(swarmClient, options));
         assertThat(thrown.getMessage(), containsString(expectedResult));
     }
 

--- a/client/src/test/java/hudson/plugins/swarm/RetryBackOffStrategyTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/RetryBackOffStrategyTest.java
@@ -33,5 +33,4 @@ public class RetryBackOffStrategyTest {
         assertEquals(80, exponential.waitForRetry(3, 10, 100));
         assertEquals(100, exponential.waitForRetry(4, 10, 100));
     }
-
 }

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -66,13 +66,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <argLine>-Xmx256m -Xms256m</argLine>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.jenkins-ci.tools</groupId>
           <artifactId>maven-hpi-plugin</artifactId>
           <configuration>

--- a/plugin/src/main/java/hudson/plugins/swarm/DownloadClientAction.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/DownloadClientAction.java
@@ -3,13 +3,17 @@ package hudson.plugins.swarm;
 import hudson.Extension;
 import hudson.Plugin;
 import hudson.model.UnprotectedRootAction;
-import java.io.IOException;
-import javax.servlet.ServletException;
+
 import jenkins.model.Jenkins;
+
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
 
 @Extension
 public class DownloadClientAction implements UnprotectedRootAction {
@@ -31,7 +35,8 @@ public class DownloadClientAction implements UnprotectedRootAction {
 
     // serve static resources
     @Restricted(NoExternalUse.class)
-    public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
+    public void doDynamic(StaplerRequest req, StaplerResponse rsp)
+            throws IOException, ServletException {
         Plugin plugin = Jenkins.get().getPlugin("swarm");
         if (plugin != null) {
             plugin.doDynamic(req, rsp);

--- a/plugin/src/main/java/hudson/plugins/swarm/SwarmLauncher.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/SwarmLauncher.java
@@ -14,8 +14,9 @@ import jenkins.slaves.DefaultJnlpSlaveReceiver;
 
 import org.jenkinsci.remoting.engine.JnlpConnectionState;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
+
+import javax.annotation.Nonnull;
 
 /**
  * {@link ComputerLauncher} for Swarm agents. We extend {@link JNLPLauncher} for compatibility with

--- a/plugin/src/main/java/hudson/plugins/swarm/SwarmSlave.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/SwarmSlave.java
@@ -26,17 +26,49 @@ public class SwarmSlave extends Slave implements EphemeralNode {
 
     private static final long serialVersionUID = -1527777529814020243L;
 
-    public SwarmSlave(String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode,
-                      String label, List<? extends NodeProperty<?>> nodeProperties) throws IOException, FormException {
-        super(name, nodeDescription, remoteFS, numExecutors, mode, label,
-                SELF_CLEANUP_LAUNCHER, RetentionStrategy.NOOP, nodeProperties);
+    public SwarmSlave(
+            String name,
+            String nodeDescription,
+            String remoteFS,
+            String numExecutors,
+            Mode mode,
+            String label,
+            List<? extends NodeProperty<?>> nodeProperties)
+            throws IOException, FormException {
+        super(
+                name,
+                nodeDescription,
+                remoteFS,
+                numExecutors,
+                mode,
+                label,
+                SELF_CLEANUP_LAUNCHER,
+                RetentionStrategy.NOOP,
+                nodeProperties);
     }
 
     @DataBoundConstructor
-    public SwarmSlave(String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode,
-                      String labelString, ComputerLauncher launcher, RetentionStrategy<?> retentionStrategy,
-                      List<? extends NodeProperty<?>> nodeProperties) throws FormException, IOException {
-        super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
+    public SwarmSlave(
+            String name,
+            String nodeDescription,
+            String remoteFS,
+            String numExecutors,
+            Mode mode,
+            String labelString,
+            ComputerLauncher launcher,
+            RetentionStrategy<?> retentionStrategy,
+            List<? extends NodeProperty<?>> nodeProperties)
+            throws FormException, IOException {
+        super(
+                name,
+                nodeDescription,
+                remoteFS,
+                numExecutors,
+                mode,
+                labelString,
+                launcher,
+                retentionStrategy,
+                nodeProperties);
     }
 
     @Override
@@ -52,17 +84,13 @@ public class SwarmSlave extends Slave implements EphemeralNode {
             return "Swarm agent";
         }
 
-        /**
-         * We only create this kind of nodes programmatically.
-         */
+        /** We only create this kind of nodes programmatically. */
         @Override
         public boolean isInstantiable() {
             return false;
         }
     }
 
-    /**
-     * {@link ComputerLauncher} that destroys itself upon a connection termination.
-     */
+    /** {@link ComputerLauncher} that destroys itself upon a connection termination. */
     private static final ComputerLauncher SELF_CLEANUP_LAUNCHER = new SwarmLauncher();
 }

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -353,7 +353,7 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void workDirEnabledByDefaultWithFsRootAsDefaultPath() throws Exception {
-        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         swarmClientRule.createSwarmClient("-fsroot", fsRootPath.getAbsolutePath());
 
         assertDirectories(
@@ -365,7 +365,7 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void workDirWithCustomPath() throws Exception {
-        final File workDirPath = new File(temporaryRemotingFolder.getRoot(), "customworkdir");
+        File workDirPath = new File(temporaryRemotingFolder.getRoot(), "customworkdir");
         swarmClientRule.createSwarmClient("-workDir", workDirPath.getAbsolutePath());
 
         assertDirectories(
@@ -377,7 +377,7 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void disableWorkDirRunsInLegacyMode() throws Exception {
-        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         swarmClientRule.createSwarmClient(
                 "-fsroot", fsRootPath.getAbsolutePath(), "-disableWorkDir");
 
@@ -390,8 +390,8 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void failIfWorkDirIsMissingDoesNothingIfDirectoryExists() throws Exception {
-        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        final File workDirPath = temporaryFolder.newFolder("remoting");
+        File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        File workDirPath = temporaryFolder.newFolder("remoting");
         swarmClientRule.createSwarmClient(
                 "-fsroot",
                 fsRootPath.getAbsolutePath(),
@@ -408,8 +408,8 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void failIfWorkDirIsMissingFailsOnMissingWorkDir() throws Exception {
-        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        final File workDirPath = new File(temporaryRemotingFolder.getRoot(), "customworkdir");
+        File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        File workDirPath = new File(temporaryRemotingFolder.getRoot(), "customworkdir");
         startFailingSwarmClient(
                 j.getURL(),
                 "should_fail",
@@ -434,7 +434,7 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void internalDirIsInWorkDirByDefault() throws Exception {
-        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         swarmClientRule.createSwarmClient("-fsroot", fsRootPath.getAbsolutePath());
 
         assertDirectories(
@@ -446,7 +446,7 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void internalDirWithCustomPath() throws Exception {
-        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
         swarmClientRule.createSwarmClient(
                 "-fsroot", fsRootPath.getAbsolutePath(), "-internalDir", "custominternaldir");
 
@@ -459,8 +459,8 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void jarCacheWithCustomPath() throws Exception {
-        final File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
-        final File jarCachePath = new File(temporaryRemotingFolder.getRoot(), "customjarcache");
+        File fsRootPath = temporaryRemotingFolder.newFolder("fsrootdir");
+        File jarCachePath = new File(temporaryRemotingFolder.getRoot(), "customjarcache");
         swarmClientRule.createSwarmClient(
                 "-fsroot", fsRootPath.getAbsolutePath(), "-jar-cache", jarCachePath.getPath());
 

--- a/plugin/src/test/java/hudson/plugins/swarm/test/GlobalSecurityConfigurationBuilder.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/GlobalSecurityConfigurationBuilder.java
@@ -124,8 +124,9 @@ public class GlobalSecurityConfigurationBuilder {
             strategy.add(Computer.CONNECT, swarmUsername);
 
             /*
-             * The following is necessary because AuthorizationMatrixNodeProperty.NodeListenerImpl#onCreated only
-             * applies to ProjectMatrixAuthorizationStrategy.
+             * The following is necessary because
+             * AuthorizationMatrixNodeProperty.NodeListenerImpl#onCreated only applies to
+             * ProjectMatrixAuthorizationStrategy.
              */
             if (!(authorizationStrategy instanceof ProjectMatrixAuthorizationStrategy)) {
                 // Needed to add/remove labels after the fact.


### PR DESCRIPTION
Grab bag of various internal cleanup:

- Make use of `final` consistent
- Clean up exception handling in client
- Format code with `google-java-format`
- Split up long `connect()` method into two distinct parts
- Lower visibility where possible