### PR TITLE
More test stabilization

### DIFF
--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -10,6 +10,7 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
 import hudson.plugins.swarm.test.SwarmClientRule;
+import hudson.plugins.swarm.test.SwarmTemporaryFolder;
 import hudson.tasks.BatchFile;
 import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
@@ -25,7 +26,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -56,11 +56,10 @@ public class SwarmClientIntegrationTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Rule(order = 20)
-    public TemporaryFolder temporaryFolder = TemporaryFolder.builder().assureDeletion().build();
+    public SwarmTemporaryFolder temporaryFolder = new SwarmTemporaryFolder();
 
     @Rule(order = 21)
-    public TemporaryFolder temporaryRemotingFolder =
-            TemporaryFolder.builder().assureDeletion().build();
+    public SwarmTemporaryFolder temporaryRemotingFolder = new SwarmTemporaryFolder();
 
     @Rule(order = 30)
     public SwarmClientRule swarmClientRule = new SwarmClientRule(() -> j, temporaryFolder);

--- a/plugin/src/test/java/hudson/plugins/swarm/test/SwarmTemporaryFolder.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/SwarmTemporaryFolder.java
@@ -1,0 +1,44 @@
+package hudson.plugins.swarm.test;
+
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+/** Temporary override to identify which files are preventing the Windows tests from passing. */
+public class SwarmTemporaryFolder extends TemporaryFolder {
+    @Override
+    public void delete() {
+        File folder = getRoot();
+        if (folder != null) {
+            Path root = folder.toPath();
+            try {
+                Files.walkFileTree(
+                        root,
+                        new SimpleFileVisitor<Path>() {
+                            @Override
+                            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                                    throws IOException {
+                                Files.delete(file);
+                                return FileVisitResult.CONTINUE;
+                            }
+
+                            @Override
+                            public FileVisitResult postVisitDirectory(Path dir, IOException exc)
+                                    throws IOException {
+                                Files.delete(dir);
+                                return FileVisitResult.CONTINUE;
+                            }
+                        });
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Windows tests are sometimes failing with

```
java.lang.AssertionError: Unable to clean up temporary folder C:\Jenkins\workspace\Plugins_swarm-plugin_master\plugin\target\tmp\junit6993291819068157345
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.rules.TemporaryFolder.delete(TemporaryFolder.java:274)
	at org.junit.rules.TemporaryFolder.after(TemporaryFolder.java:138)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:59)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:594)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:288)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:282)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

Unfortunately, the error message doesn't indicate which file couldn't be deleted. This PR uses NIO.2 to delete files and fails the test fast when a file cannot be deleted so that we can hopefully identify which file cannot be deleted.