### PR TITLE
Fix flaky disconnection-related tests in PipelineJobTest#buildShellScriptAcrossDisconnect

### DIFF
--- a/plugin/src/test/java/hudson/plugins/swarm/PipelineJobTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/PipelineJobTest.java
@@ -101,7 +101,7 @@ public class PipelineJobTest {
                         + "\";"
                         + "while [ -f \""
                         + f1
-                        + "\" ]; do sleep 1; done;"
+                        + "\" ]; do echo waiting; sleep 1; done;"
                         + "echo finished waiting;"
                         + "rm \""
                         + f2
@@ -115,6 +115,7 @@ public class PipelineJobTest {
         while (!f2.isFile()) {
             Thread.sleep(100L);
         }
+        j.waitForMessage("waiting", build);
         assertTrue(build.isBuilding());
         Computer computer = node.toComputer();
         assertNotNull(computer);

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.4</version>
+        <version>4.6</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Applies recent changes from `workflow-durable-task-step` to the corresponding test in Swarm.