### PR TITLE
Migrate from HttpComponents Client 4.5.x to HttpComponents Client 5.0.x

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -126,9 +126,9 @@
             <version>4.5</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.12</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.0.1</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -1,6 +1,7 @@
 package hudson.plugins.swarm;
 
 import org.apache.commons.lang.math.NumberUtils;
+import org.apache.hc.core5.http.ParseException;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.NamedOptionDef;
@@ -193,7 +194,7 @@ public class Client {
                     logger.warning("Connection closed, exiting...");
                     swarmClient.exitWithStatus(0);
                 }
-            } catch (IOException | RetryException e) {
+            } catch (IOException | ParseException | RetryException e) {
                 logger.log(Level.SEVERE, "An error occurred", e);
             }
 

--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -3,11 +3,12 @@ package hudson.plugins.swarm;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ParseException;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -80,11 +81,11 @@ public class LabelFileWatcher implements Runnable {
 
         HttpGet get = new HttpGet(masterUrl + "/plugin/swarm/getSlaveLabels?name=" + name);
         try (CloseableHttpResponse response = client.execute(get, context)) {
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+            if (response.getCode() != HttpStatus.SC_OK) {
                 logger.log(
                         Level.CONFIG,
                         "Failed to retrieve labels from master -- Response code: "
-                                + response.getStatusLine().getStatusCode());
+                                + response.getCode());
                 throw new SoftLabelUpdateException(
                         "Unable to acquire labels from master to begin removal process.");
             }
@@ -115,7 +116,7 @@ public class LabelFileWatcher implements Runnable {
             if (sb.length() > 1000) {
                 try {
                     SwarmClient.postLabelRemove(name, sb.toString(), client, context, masterUrl);
-                } catch (IOException | RetryException e) {
+                } catch (IOException | ParseException | RetryException e) {
                     String msg = "Exception when removing label from " + masterUrl;
                     logger.log(Level.SEVERE, msg, e);
                     throw new SoftLabelUpdateException(msg);
@@ -126,7 +127,7 @@ public class LabelFileWatcher implements Runnable {
         if (sb.length() > 0) {
             try {
                 SwarmClient.postLabelRemove(name, sb.toString(), client, context, masterUrl);
-            } catch (IOException | RetryException e) {
+            } catch (IOException | ParseException | RetryException e) {
                 String msg = "Exception when removing label from " + masterUrl;
                 logger.log(Level.SEVERE, msg, e);
                 throw new SoftLabelUpdateException(msg);
@@ -143,7 +144,7 @@ public class LabelFileWatcher implements Runnable {
             if (sb.length() > 1000) {
                 try {
                     SwarmClient.postLabelAppend(name, sb.toString(), client, context, masterUrl);
-                } catch (IOException | RetryException e) {
+                } catch (IOException | ParseException | RetryException e) {
                     String msg = "Exception when appending label to " + masterUrl;
                     logger.log(Level.SEVERE, msg, e);
                     throw new SoftLabelUpdateException(msg);
@@ -155,7 +156,7 @@ public class LabelFileWatcher implements Runnable {
         if (sb.length() > 0) {
             try {
                 SwarmClient.postLabelAppend(name, sb.toString(), client, context, masterUrl);
-            } catch (IOException | RetryException e) {
+            } catch (IOException | ParseException | RetryException e) {
                 String msg = "Exception when appending label to " + masterUrl;
                 logger.log(Level.SEVERE, msg, e);
                 throw new SoftLabelUpdateException(msg);

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -7,24 +7,26 @@ import hudson.remoting.jnlp.Main;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.Header;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpStatus;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.AuthCache;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.auth.BasicScheme;
-import org.apache.http.impl.client.BasicAuthCache;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.util.EntityUtils;
+import org.apache.hc.client5.http.auth.AuthCache;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.auth.BasicAuthCache;
+import org.apache.hc.client5.http.impl.auth.BasicScheme;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.ssl.SSLContexts;
 import org.jenkinsci.remoting.util.VersionNumber;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -258,7 +260,14 @@ public class SwarmClient {
         HttpClientBuilder builder = HttpClientBuilder.create();
         builder.useSystemProperties();
         if (clientOptions.disableSslVerification) {
-            builder.setSSLHostnameVerifier(new NoopHostnameVerifier());
+            SSLConnectionSocketFactory sslsf =
+                    new SSLConnectionSocketFactory(
+                            SSLContexts.createDefault(), new NoopHostnameVerifier());
+            HttpClientConnectionManager cm =
+                    PoolingHttpClientConnectionManagerBuilder.create()
+                            .setSSLSocketFactory(sslsf)
+                            .build();
+            builder.setConnectionManager(cm);
         }
         return builder.build();
     }
@@ -271,18 +280,18 @@ public class SwarmClient {
         if (clientOptions.username != null && clientOptions.password != null) {
             logger.fine("Setting HttpClient credentials based on options passed");
 
-            CredentialsProvider credsProvider = new BasicCredentialsProvider();
-            credsProvider.setCredentials(
-                    new AuthScope(urlForAuth.getHost(), urlForAuth.getPort()),
+            BasicScheme basicScheme = new BasicScheme();
+            basicScheme.initPreemptive(
                     new UsernamePasswordCredentials(
-                            clientOptions.username, clientOptions.password));
-            context.setCredentialsProvider(credsProvider);
+                            clientOptions.username, clientOptions.password.toCharArray()));
+
+            HttpHost host =
+                    new HttpHost(
+                            urlForAuth.getProtocol(), urlForAuth.getHost(), urlForAuth.getPort());
+            context.resetAuthExchange(host, basicScheme);
 
             AuthCache authCache = new BasicAuthCache();
-            authCache.put(
-                    new HttpHost(
-                            urlForAuth.getHost(), urlForAuth.getPort(), urlForAuth.getProtocol()),
-                    new BasicScheme());
+            authCache.put(host, basicScheme);
             context.setAuthCache(authCache);
         }
 
@@ -294,7 +303,7 @@ public class SwarmClient {
             justification = "False positive for try-with-resources in Java 11")
     private static synchronized Crumb getCsrfCrumb(
             CloseableHttpClient client, HttpClientContext context, URL masterUrl)
-            throws IOException {
+            throws IOException, ParseException {
         logger.finer("getCsrfCrumb() invoked");
 
         String[] crumbResponse;
@@ -306,12 +315,12 @@ public class SwarmClient {
                                 + URLEncoder.encode(
                                         "concat(//crumbRequestField,\":\",//crumb)", "UTF-8"));
         try (CloseableHttpResponse response = client.execute(httpGet, context)) {
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+            if (response.getCode() != HttpStatus.SC_OK) {
                 logger.log(
                         Level.SEVERE,
                         String.format(
                                 "Could not obtain CSRF crumb. Response code: %s%n%s",
-                                response.getStatusLine().getStatusCode(),
+                                response.getCode(),
                                 EntityUtils.toString(
                                         response.getEntity(), StandardCharsets.UTF_8)));
                 return null;
@@ -332,7 +341,7 @@ public class SwarmClient {
     @SuppressFBWarnings(
             value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
             justification = "False positive for try-with-resources in Java 11")
-    void createSwarmAgent(URL masterUrl) throws IOException, RetryException {
+    void createSwarmAgent(URL masterUrl) throws IOException, ParseException, RetryException {
         logger.fine("createSwarmAgent() invoked");
 
         CloseableHttpClient client = createHttpClient(options);
@@ -407,11 +416,11 @@ public class SwarmClient {
         }
 
         try (CloseableHttpResponse response = client.execute(post, context)) {
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+            if (response.getCode() != HttpStatus.SC_OK) {
                 throw new RetryException(
                         String.format(
                                 "Failed to create a Swarm agent on Jenkins. Response code: %s%n%s",
-                                response.getStatusLine().getStatusCode(),
+                                response.getCode(),
                                 EntityUtils.toString(
                                         response.getEntity(), StandardCharsets.UTF_8)));
             }
@@ -460,7 +469,7 @@ public class SwarmClient {
             CloseableHttpClient client,
             HttpClientContext context,
             URL masterUrl)
-            throws IOException, RetryException {
+            throws IOException, ParseException, RetryException {
         HttpPost post =
                 new HttpPost(
                         masterUrl
@@ -476,11 +485,11 @@ public class SwarmClient {
         }
 
         try (CloseableHttpResponse response = client.execute(post, context)) {
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+            if (response.getCode() != HttpStatus.SC_OK) {
                 throw new RetryException(
                         String.format(
                                 "Failed to remove agent labels. Response code: %s%n%s",
-                                response.getStatusLine().getStatusCode(),
+                                response.getCode(),
                                 EntityUtils.toString(
                                         response.getEntity(), StandardCharsets.UTF_8)));
             }
@@ -496,7 +505,7 @@ public class SwarmClient {
             CloseableHttpClient client,
             HttpClientContext context,
             URL masterUrl)
-            throws IOException, RetryException {
+            throws IOException, ParseException, RetryException {
         HttpPost post =
                 new HttpPost(
                         masterUrl
@@ -512,11 +521,11 @@ public class SwarmClient {
         }
 
         try (CloseableHttpResponse response = client.execute(post, context)) {
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+            if (response.getCode() != HttpStatus.SC_OK) {
                 throw new RetryException(
                         String.format(
                                 "Failed to update agent labels. Response code: %s%n%s",
-                                response.getStatusLine().getStatusCode(),
+                                response.getCode(),
                                 EntityUtils.toString(
                                         response.getEntity(), StandardCharsets.UTF_8)));
             }
@@ -545,16 +554,16 @@ public class SwarmClient {
             justification = "False positive for try-with-resources in Java 11")
     VersionNumber getJenkinsVersion(
             CloseableHttpClient client, HttpClientContext context, URL masterUrl)
-            throws IOException, RetryException {
+            throws IOException, ParseException, RetryException {
         logger.fine("getJenkinsVersion() invoked");
 
         HttpGet httpGet = new HttpGet(masterUrl + "api");
         try (CloseableHttpResponse response = client.execute(httpGet, context)) {
-            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+            if (response.getCode() != HttpStatus.SC_OK) {
                 throw new RetryException(
                         String.format(
                                 "Could not get Jenkins version. Response code: %s%n%s",
-                                response.getStatusLine().getStatusCode(),
+                                response.getCode(),
                                 EntityUtils.toString(
                                         response.getEntity(), StandardCharsets.UTF_8)));
             }

--- a/client/src/test/java/hudson/plugins/swarm/SwarmClientTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/SwarmClientTest.java
@@ -2,7 +2,7 @@ package hudson.plugins.swarm;
 
 import static org.junit.Assert.assertNotNull;
 
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.junit.Test;
 
 import java.io.IOException;

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -1,8 +1,8 @@
 # Proxy Configuration
 
 Swarm uses
-[`SystemDefaultHttpClient`](https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/SystemDefaultHttpClient.html),
-which supports customization of the HTTP client through 18 different Java
+[`HttpClientBuilder`](https://hc.apache.org/httpcomponents-client-5.0.x/httpclient5/apidocs/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.html),
+which supports customization of the HTTP client through system
 properties. Use the following system properties to configure a proxy:
 
 * `http.proxyHost`


### PR DESCRIPTION
Swarm currently uses [HttpComponents Client 4.5.x](https://hc.apache.org/httpcomponents-client-4.5.x/index.html), which has been superseded by [HttpComponents Client 5.0.x](https://hc.apache.org/httpcomponents-client-5.0.x/index.html). 
I followed these examples to perform the migration:

- [Migration to Apache HttpClient 5.0 classic APIs](https://ok2c.github.io/httpclient-migration-guide/migration-to-classic.html)
- [Preemptive `BASIC` authentication](https://hc.apache.org/httpcomponents-client-5.0.x/httpclient5/examples/ClientPreemptiveBasicAuthentication.java)
- [Custom public suffix list](https://hc.apache.org/httpcomponents-client-5.0.x/httpclient5/examples/ClientCustomPublicSuffixList.java)