### PR TITLE
Remove support for Swarm clients older than 3.21

### DIFF
--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -286,29 +286,4 @@ public class PluginImpl extends Plugin {
 
         return result;
     }
-
-    /**
-     * This merely exists to support older versions of the Swarm client that expect to be able to
-     * retrieve a UUID-based secret. Security is now handled through CSRF and permission checks
-     * rather than a UUID-based secret. Newer clients do not call this method or pass in a
-     * UUID-based secret, and newer versions of the server do not check for a UUID-based secret.
-     * When support for older clients that call this endpoint is removed, this endpoint can be
-     * deleted.
-     */
-    @Deprecated
-    @SuppressFBWarnings(
-            value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
-            justification = "False positive for try-with-resources in Java 11")
-    public void doSlaveInfo(StaplerRequest req, StaplerResponse rsp) throws IOException {
-        Jenkins jenkins = Jenkins.get();
-        jenkins.checkPermission(Computer.CREATE);
-
-        rsp.setContentType("text/xml");
-        try (Writer writer = rsp.getCompressedWriter(req)) {
-            writer.write(
-                    "<slaveInfo><swarmSecret>"
-                            + UUID.randomUUID().toString()
-                            + "</swarmSecret></slaveInfo>");
-        }
-    }
 }


### PR DESCRIPTION
With the fix for [SECURITY-1200](https://www.jenkins.io/security/advisory/2020-06-03/#SECURITY-1200) in [3.21](https://github.com/jenkinsci/swarm-plugin/releases/tag/swarm-plugin-3.21), support for versions of the Swarm client older than 3.21 was deprecated. As of this PR, support for Swarm clients older than 3.21 is removed. As a general reminder, users are strongly encouraged to update the Swarm plugin and client in lockstep.