### PR TITLE
README.adoc: add a link to Download Swarm Client in the top bar

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,7 @@ https://github.com/jenkinsci/swarm-plugin/graphs/contributors[image:https://img.
 https://plugins.jenkins.io/swarm[image:https://img.shields.io/jenkins/plugin/v/swarm.svg[Jenkins Plugin]]
 https://github.com/jenkinsci/swarm-plugin/releases/latest[image:https://img.shields.io/github/release/jenkinsci/swarm-plugin.svg?label=changelog[GitHub release]]
 https://plugins.jenkins.io/swarm[image:https://img.shields.io/jenkins/plugin/i/swarm.svg?color=blue[Jenkins Plugin Installs]]
+https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/[Download Swarm Client]
 
 toc::[]
 

--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ https://github.com/jenkinsci/swarm-plugin/graphs/contributors[image:https://img.
 https://plugins.jenkins.io/swarm[image:https://img.shields.io/jenkins/plugin/v/swarm.svg[Jenkins Plugin]]
 https://github.com/jenkinsci/swarm-plugin/releases/latest[image:https://img.shields.io/github/release/jenkinsci/swarm-plugin.svg?label=changelog[GitHub release]]
 https://plugins.jenkins.io/swarm[image:https://img.shields.io/jenkins/plugin/i/swarm.svg?color=blue[Jenkins Plugin Installs]]
-https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/[Download Swarm Client]
+https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/[image:https://img.shields.io/badge/download-swarm--client-blue[Download Swarm Client]]
 
 toc::[]
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

This is a small change aiming for https://plugins.jenkins.io/swarm/ page to display the download link visibly (there is one, lost in the wall of text, which makes quick new deployments bumpy). Sadly, the repo does not have a "latest" symlink for this like the jenkins.war distributions, so the best we can point to is the location with all versions (alternately have to update the README with every release to bump the link).