### PR TITLE
README.adoc: add common rationales for Swarm in the intro

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ toc::[]
 == Introduction
 
 The Swarm plugin enables nodes to join a nearby Jenkins controller, thereby forming an ad-hoc cluster.
-This plugin makes it easier to scale a Jenkins cluster by spinning up and tearing down new nodes.
+This plugin makes it easier to scale a Jenkins cluster by spinning up and tearing down new nodes, for team members to contribute compute resources to a build farm, or to attach builders that the Jenkins controller can not initiate connections to.
 
 This plugin consists of two pieces:
 

--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ toc::[]
 == Introduction
 
 The Swarm plugin enables nodes to join a nearby Jenkins controller, thereby forming an ad-hoc cluster.
-This plugin makes it easier to scale a Jenkins cluster by spinning up and tearing down new nodes, for team members to contribute compute resources to a build farm, or to attach builders that the Jenkins controller can not initiate connections to.
+This plugin makes it easier to scale a Jenkins cluster by spinning up and tearing down new agents, enabling team members to contribute compute resources to a build farm or to attach agents to which the Jenkins controller cannot initiate connections.
 
 This plugin consists of two pieces:
 

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,8 @@ Because the Swarm client is running on a separate VM, there is no need to worry 
 == Getting started
 
 . Install the Swarm plugin from the Update Center.
-. Download https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/[the Swarm client] on your worker machine or container (JRE 8+ also needed there).
+. Ensure your agent is running version 8 or later of the Java Runtime Environment (JRE). The recommendation is to use the same JRE distribution and version as the controller.
+. Download https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/[the Swarm client] on your agent.
 . Run the Swarm client with `java -jar path/to/swarm-client.jar -master JENKINS_URL -username SWARM_ACCOUNT -password...` (note there are several ways to pass a password/token, of varying security; the account should have permissions set up to interact with the swarm-plugin on server side -- see Security document referenced below for details). There are no other required command-line options; run with the `-help` option to see the available options.
 
 == Documentation

--- a/README.adoc
+++ b/README.adoc
@@ -34,8 +34,8 @@ Because the Swarm client is running on a separate VM, there is no need to worry 
 == Getting started
 
 . Install the Swarm plugin from the Update Center.
-. Download https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/[the Swarm client].
-. Run the Swarm client with `java -jar path/to/swarm-client.jar`. There are no required command-line options; run with the `-help` option to see the available options.
+. Download https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/[the Swarm client] on your worker machine or container (JRE 8+ also needed there).
+. Run the Swarm client with `java -jar path/to/swarm-client.jar -master JENKINS_URL -username SWARM_ACCOUNT -password...` (note there are several ways to pass a password/token, of varying security; the account should have permissions set up to interact with the swarm-plugin on server side -- see Security document referenced below for details). There are no other required command-line options; run with the `-help` option to see the available options.
 
 == Documentation
 

--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ Because the Swarm client is running on a separate VM, there is no need to worry 
 . Install the Swarm plugin from the Update Center.
 . Ensure your agent is running version 8 or later of the Java Runtime Environment (JRE). The recommendation is to use the same JRE distribution and version as the controller.
 . Download https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/[the Swarm client] on your agent.
-. Run the Swarm client with `java -jar path/to/swarm-client.jar -master JENKINS_URL -username SWARM_ACCOUNT -password...` (note there are several ways to pass a password/token, of varying security; the account should have permissions set up to interact with the swarm-plugin on server side -- see Security document referenced below for details). There are no other required command-line options; run with the `-help` option to see the available options.
+. Run the Swarm client with `java -jar path/to/swarm-client.jar -master ${JENKINS_URL} -username ${USERNAME}` and one of the authentication options as described in xref:docs/security.adoc#authentication[the Global Security Configuration documentation]. There are no other required command-line options; run with the `-help` option to see the available options.
 
 == Documentation
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

Updated the README which used to say no arguments are required: in version 3.25 the JAR refuses to start without a `-master URL` CLI option. Technically options to log in may be not required, if the anonymous user is given `Agent/*` permissions in the Matrix strategy (checked to be so) - but this is not something we would encourage, right?