### PR TITLE
Use consistent terminology for Jenkins controller

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,7 @@ Because the Swarm client is running on a separate VM, there is no need to worry 
 . Install the Swarm plugin from the Update Center.
 . Ensure your agent is running version 8 or later of the Java Runtime Environment (JRE). The recommendation is to use the same JRE distribution and version as the controller.
 . Download https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/[the Swarm client] on your agent.
-. Run the Swarm client with `java -jar path/to/swarm-client.jar -master ${JENKINS_URL} -username ${USERNAME}` and one of the authentication options as described in xref:docs/security.adoc#authentication[the Global Security Configuration documentation]. There are no other required command-line options; run with the `-help` option to see the available options.
+. Run the Swarm client with `java -jar path/to/swarm-client.jar -url ${JENKINS_URL} -username ${USERNAME}` and one of the authentication options as described in xref:docs/security.adoc#authentication[the Global Security Configuration documentation]. There are no other required command-line options; run with the `-help` option to see the available options.
 
 == Documentation
 
@@ -65,10 +65,9 @@ Because the Swarm client is running on a separate VM, there is no need to worry 
 |`-fsroot FILE` |Remote root directory. (default: .)
 |`-help (--help, -h)` |Show the help screen (default: false)
 |`-internalDir FILE` |The name of the directory within the Remoting working directory where files internal to Remoting will be stored.
-|`-jar-cache FILE` |Cache directory that stores JAR files sent from the master.
+|`-jar-cache FILE` |Cache directory that stores JAR files sent from the controller.
 |`-labels VAL` |Whitespace-separated list of labels to be assigned for this agent. Multiple options are allowed.
 |`-labelsFile VAL` |File location with space delimited list of labels. If the file changes, the client is restarted.
-|`-master VAL` |The complete target Jenkins URL like `http://server:8080/jenkins/'.
 |`-maxRetryInterval N` |Max time to wait before retry in seconds. Default is 60 seconds. (default: 60)
 |`-mode MODE` |The mode controlling how Jenkins allocates jobs to agents. Can be either `normal' (use this node as much as possible) or `exclusive' (only build jobs with label expressions matching this node). Default is `normal'. (default: normal)
 |`-name VAL` |Name of the agent.
@@ -84,6 +83,7 @@ Because the Swarm client is running on a separate VM, there is no need to worry 
 |`-sslFingerprints VAL` |Whitespace-separated list of accepted certificate fingerprints (SHA-256/Hex), otherwise system truststore will be used. No revocation, expiration or not yet valid check will be performed for custom fingerprints! Multiple options are allowed. (default: )
 |`-t (--toolLocation)` |A tool location to be defined on this agent. It is specified as `toolName=location'.
 |`-tunnel VAL` |Connect to the specified host and port, instead of connecting directly to Jenkins. Useful when connection to Jenkins needs to be tunneled. Can be also HOST: or :PORT, in which case the missing portion will be auto-configured like the default behavior
+|`-url (-master) VAL` |The complete target Jenkins URL like `http://server:8080/jenkins/'.
 |`-username VAL` |The Jenkins username for authentication.
 |`-webSocket` |Connect using the WebSocket protocol. (default: false)
 |`-workDir FILE` |The Remoting working directory where the JAR cache and logs will be stored.

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -147,27 +147,27 @@ public class Client {
     }
 
     /**
-     * Finds a Jenkins master that supports swarming, and join it.
+     * Run the Swarm client.
      *
      * <p>This method never returns.
      */
     static void run(SwarmClient swarmClient, Options options, String... args)
             throws InterruptedException {
-        logger.info("Connecting to Jenkins master");
-        URL masterUrl = swarmClient.getMasterUrl();
+        logger.info("Connecting to Jenkins controller");
+        URL url = swarmClient.getUrl();
 
         // wait until we get the ACK back
         int retry = 0;
         while (true) {
             try {
-                logger.info("Attempting to connect to " + masterUrl);
+                logger.info("Attempting to connect to " + url);
 
                 /*
                  * Create a new Swarm agent. After this method returns, the value of the name field
                  * has been set to the name returned by the server, which may or may not be the name
                  * we originally requested.
                  */
-                swarmClient.createSwarmAgent(masterUrl);
+                swarmClient.createSwarmAgent(url);
 
                 /*
                  * Set up the label file watcher thread. If the label file changes, this thread
@@ -178,7 +178,7 @@ public class Client {
                 if (options.labelsFile != null) {
                     logger.info("Setting up LabelFileWatcher");
                     LabelFileWatcher l =
-                            new LabelFileWatcher(masterUrl, options, swarmClient.getName(), args);
+                            new LabelFileWatcher(url, options, swarmClient.getName(), args);
                     Thread labelFileWatcherThread = new Thread(l, "LabelFileWatcher");
                     labelFileWatcherThread.setDaemon(true);
                     labelFileWatcherThread.start();
@@ -188,8 +188,8 @@ public class Client {
                  * Note that any instances of InterruptedException or RuntimeException thrown
                  * internally by the next two lines get wrapped in RetryException.
                  */
-                List<String> jnlpArgs = swarmClient.getJnlpArgs(masterUrl);
-                swarmClient.connect(jnlpArgs, masterUrl);
+                List<String> jnlpArgs = swarmClient.getJnlpArgs(url);
+                swarmClient.connect(jnlpArgs, url);
                 if (options.noRetryAfterConnected) {
                     logger.warning("Connection closed, exiting...");
                     swarmClient.exitWithStatus(0);

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -30,10 +30,11 @@ public class Options {
     public int executors = Runtime.getRuntime().availableProcessors();
 
     @Option(
-            name = "-master",
+            name = "-url",
+            aliases = "-master",
             usage = "The complete target Jenkins URL like 'http://server:8080/jenkins/'.",
             required = true)
-    public String master;
+    public String url;
 
     @Option(
             name = "-tunnel",
@@ -193,7 +194,7 @@ public class Options {
 
     @Option(
             name = "-jar-cache",
-            usage = "Cache directory that stores JAR files sent from the master.")
+            usage = "Cache directory that stores JAR files sent from the controller.")
     public File jarCache;
 
     @Option(

--- a/client/src/test/java/hudson/plugins/swarm/ClientTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/ClientTest.java
@@ -60,7 +60,7 @@ public class ClientTest {
 
     private Options givenBackOff(RetryBackOffStrategy retryBackOffStrategy) {
         Options options = new Options();
-        options.master = "http://localhost:8080";
+        options.url = "http://localhost:8080";
         options.retryBackOffStrategy = retryBackOffStrategy;
         options.retry = 10;
         options.retryInterval = 10;
@@ -84,7 +84,7 @@ public class ClientTest {
         }
 
         @Override
-        protected void createSwarmAgent(URL masterUrl) throws RetryException {
+        protected void createSwarmAgent(URL url) throws RetryException {
             throw new RetryException("try again");
         }
 

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -35,7 +35,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
-import java.util.UUID;
 
 /**
  * Exposes an entry point to add a new Swarm agent.
@@ -175,7 +174,7 @@ public class PluginImpl extends Plugin {
         if (hash == null && jenkins.getNode(name) != null && !deleteExistingClients) {
             /*
              * This is a legacy client. They won't be able to pick up the new name, so throw them
-             * away. Perhaps they can find another master to connect to.
+             * away. Perhaps they can find another controller to connect to.
              */
             rsp.setStatus(SC_CONFLICT);
             rsp.setContentType("text/plain; UTF-8");

--- a/plugin/src/test/java/hudson/plugins/swarm/PipelineJobTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/PipelineJobTest.java
@@ -57,8 +57,8 @@ public class PipelineJobTest {
     }
 
     /**
-     * Executes a shell script build on a Swarm agent that has disconnected while the Jenkins master
-     * is still running.
+     * Executes a shell script build on a Swarm agent that has disconnected while the Jenkins
+     * controller is still running.
      */
     @Test
     public void buildShellScriptAfterDisconnect() throws Exception {

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -350,7 +350,7 @@ public class SwarmClientIntegrationTest {
     }
 
     @Test
-    public void missingMasterOption() throws Exception {
+    public void missingUrlOption() throws Exception {
         startFailingSwarmClient(null, "test");
     }
 
@@ -511,13 +511,13 @@ public class SwarmClientIntegrationTest {
 
     /**
      * This is a subset of {@link SwarmClientRule#createSwarmClientWithName(String, String...)}. It
-     * does not wait for the agent to be added on the Jenkins master, nor does it check for whether
-     * a Swarm client is already running. Clients started with this method are expected to fail to
-     * start.
+     * does not wait for the agent to be added on the Jenkins controller, nor does it check for
+     * whether a Swarm client is already running. Clients started with this method are expected to
+     * fail to start.
      */
     private void startFailingSwarmClient(URL url, String agentName, String... args)
             throws IOException, InterruptedException {
-        // Download the Swarm client JAR from the Jenkins master.
+        // Download the Swarm client JAR from the Jenkins controller.
         Path swarmClientJar =
                 Files.createTempFile(temporaryFolder.getRoot().toPath(), "swarm-client", ".jar");
         swarmClientRule.download(swarmClientJar);

--- a/plugin/src/test/java/hudson/plugins/swarm/test/GlobalSecurityConfigurationBuilder.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/GlobalSecurityConfigurationBuilder.java
@@ -22,7 +22,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 /**
- * A helper class that configures the test Jenkins master with various realistic global security
+ * A helper class that configures the test Jenkins controller with various realistic global security
  * configurations.
  */
 public class GlobalSecurityConfigurationBuilder {

--- a/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
@@ -62,10 +62,10 @@ public class SwarmClientRule extends ExternalResource {
     /** Whether or not the client is currently active. */
     private boolean isActive = false;
 
-    /** The username to use when connecting to the Jenkins master. */
+    /** The username to use when connecting to the Jenkins controller. */
     String swarmUsername;
 
-    /** The password or API token to use when connecting to the Jenkins master. */
+    /** The password or API token to use when connecting to the Jenkins controller. */
     String swarmPassword;
 
     /**
@@ -136,7 +136,7 @@ public class SwarmClientRule extends ExternalResource {
                             + " creating a new one.");
         }
 
-        // Download the Swarm client JAR from the Jenkins master.
+        // Download the Swarm client JAR from the Jenkins controller.
         Path swarmClientJar =
                 Files.createTempFile(temporaryFolder.getRoot().toPath(), "swarm-client", ".jar");
         download(swarmClientJar);
@@ -212,7 +212,7 @@ public class SwarmClientRule extends ExternalResource {
      * A helper method to get the command-line arguments to start the client.
      *
      * @param swarmClientJar The path to the client JAR.
-     * @param url The URL of the Jenkins master, if one is being provided to the client.
+     * @param url The URL of the Jenkins controller, if one is being provided to the client.
      * @param agentName The proposed name of the agent.
      * @param args Any other desired arguments.
      */
@@ -233,7 +233,7 @@ public class SwarmClientRule extends ExternalResource {
         command.add("-jar");
         command.add(swarmClientJar.toString());
         if (url != null) {
-            command.add("-master");
+            command.add("-url");
             command.add(url.toString());
         }
         command.add("-name");
@@ -378,9 +378,11 @@ public class SwarmClientRule extends ExternalResource {
                 }
             }
 
-            // Wait for the agent to be disconnected from the master
+            // Wait for the agent to be disconnected from the controller
             if (computer != null) {
-                logger.log(Level.INFO, "Waiting for the agent to be disconnected from the master.");
+                logger.log(
+                        Level.INFO,
+                        "Waiting for the agent to be disconnected from the controller.");
                 try (Timeout t = Timeout.limit(60, TimeUnit.SECONDS)) {
                     computer.disconnect(null);
                     while (computer.isOnline()) {


### PR DESCRIPTION
Adding a new `-url` parameter (matching that of Remoting's [`hudson.remoting.jnlp.Main`](https://github.com/jenkinsci/remoting/blob/master/src/main/java/hudson/remoting/jnlp/Main.java)) for specifying the URL of the Jenkins controller. Retaining the old `-master` parameter as a deprecated alias for backward compatibility.