### PR TITLE
Custom WebSocket header support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -88,6 +88,7 @@ Because the Swarm client is running on a separate VM, there is no need to worry 
 |`-url (-master) VAL` |The complete target Jenkins URL like `http://server:8080/jenkins/'.
 |`-username VAL` |The Jenkins username for authentication.
 |`-webSocket` |Connect using the WebSocket protocol. (default: false)
+|`-webSocketHeader NAME=VALUE` |Additional WebSocket header to set, eg for authenticating with reverse proxies. To specify multiple headers, call this flag multiple times, one with each header.
 |`-workDir FILE` |The Remoting working directory where the JAR cache and logs will be stored.
 |===
 

--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -51,6 +51,16 @@ public class Options {
     public boolean webSocket;
 
     @Option(
+            name = "-webSocketHeader",
+            usage =
+                    "Additional WebSocket header to set, eg for authenticating with reverse"
+                        + " proxies. To specify multiple headers, call this flag multiple times,"
+                        + " one with each header.",
+            metaVar = "NAME=VALUE",
+            depends = "-webSocket")
+    public Map<String, String> webSocketHeaders;
+
+    @Option(
             name = "-noRetryAfterConnected",
             usage = "Do not retry if a successful connection gets closed.")
     public boolean noRetryAfterConnected;

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -75,6 +75,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -251,6 +252,13 @@ public class SwarmClient {
 
         if (options.webSocket) {
             args.add("-webSocket");
+
+            if (options.webSocketHeaders != null) {
+                for (Map.Entry<String, String> entry : options.webSocketHeaders.entrySet()) {
+                    args.add("-webSocketHeader");
+                    args.add(entry.getValue() + "=" + entry.getValue());
+                }
+            }
         }
 
         try {

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -256,7 +256,7 @@ public class SwarmClient {
             if (options.webSocketHeaders != null) {
                 for (Map.Entry<String, String> entry : options.webSocketHeaders.entrySet()) {
                     args.add("-webSocketHeader");
-                    args.add(entry.getValue() + "=" + entry.getValue());
+                    args.add(entry.getKey() + "=" + entry.getValue());
                 }
             }
         }

--- a/client/src/test/java/hudson/plugins/swarm/YamlConfigTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/YamlConfigTest.java
@@ -74,10 +74,10 @@ public class YamlConfigTest {
                 "url: http://localhost:8080/jenkins\n"
                         + "toolLocations:\n"
                         + "  tool-a: /tool/path/a\n"
-                        + "  tool-b: /tool/path/b\n"
-                        + "  ENV_2: env#2\n";
+                        + "  tool-b: /tool/path/b\n";
 
         final Options options = loadYaml(yamlString);
+        assertThat(options.toolLocations.size(), equalTo(2));
         assertThat(options.toolLocations.get("tool-a"), equalTo("/tool/path/a"));
         assertThat(options.toolLocations.get("tool-b"), equalTo("/tool/path/b"));
     }
@@ -109,6 +109,7 @@ public class YamlConfigTest {
                         + "  ENV_2: env#2\n";
 
         final Options options = loadYaml(yamlString);
+        assertThat(options.environmentVariables.size(), equalTo(2));
         assertThat(options.environmentVariables.get("ENV_1"), equalTo("env#1"));
         assertThat(options.environmentVariables.get("ENV_2"), equalTo("env#2"));
     }
@@ -133,11 +134,40 @@ public class YamlConfigTest {
     }
 
     @Test
-    public void webSocketOptions() throws ConfigurationException {
+    public void webSocketOption() throws ConfigurationException {
         final String yamlString = "url: http://localhost:8080/jenkins\n" + "webSocket: true\n";
 
         final Options options = loadYaml(yamlString);
         assertThat(options.webSocket, equalTo(true));
+    }
+
+    @Test
+    public void webSocketHeadersOption() throws ConfigurationException {
+        final String yamlString =
+                "url: http://localhost:8080/jenkins\n"
+                        + "webSocket: true\n"
+                        + "webSocketHeaders:\n"
+                        + "  WS_HEADER_0: WS_VALUE_0\n"
+                        + "  WS_HEADER_1: WS_VALUE_1\n";
+
+        final Options options = loadYaml(yamlString);
+        assertThat(options.webSocketHeaders.size(), equalTo(2));
+        assertThat(options.webSocketHeaders.get("WS_HEADER_0"), equalTo("WS_VALUE_0"));
+        assertThat(options.webSocketHeaders.get("WS_HEADER_1"), equalTo("WS_VALUE_1"));
+    }
+
+    @Test
+    public void webSocketHeadersFailsIfWebSocketOptionIsNotSet() {
+        final String yamlString =
+                "url: http://localhost:8080/jenkins\n"
+                        + "webSocketHeaders:\n"
+                        + "  WS_HEADER_0: WS_VALUE_0\n"
+                        + "  WS_HEADER_1: WS_VALUE_1\n";
+
+        final Throwable ex = assertThrows(ConfigurationException.class, () -> loadYaml(yamlString));
+        assertThat(
+                ex.getMessage(),
+                allOf(containsString("webSocketHeaders"), containsString("webSocket")));
     }
 
     @Test

--- a/client/src/test/java/hudson/plugins/swarm/YamlConfigTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/YamlConfigTest.java
@@ -26,26 +26,10 @@ public class YamlConfigTest {
                         + "  - label-a\n"
                         + "  - label-b\n"
                         + "  - label-c\n"
-                        + "webSocket: true\n"
                         + "disableClientsUniqueId: true\n"
                         + "mode: exclusive\n"
-                        + "retry: 0\n"
                         + "failIfWorkDirIsMissing: false\n"
-                        + "toolLocations:\n"
-                        + "  tool-a: /tool/path/a\n"
-                        + "  tool-b: /tool/path/b\n"
-                        + "noRetryAfterConnected: true\n"
-                        + "environmentVariables:\n"
-                        + "  ENV_1: env#1\n"
-                        + "  ENV_2: env#2\n"
-                        + "retryInterval: 12\n"
-                        + "maxRetryInterval: 9\n"
-                        + "disableSslVerification: false\n"
-                        + "sslFingerprints: fp0 fp1 fp2\n"
                         + "deleteExistingClients: true\n"
-                        + "username: swarm-user-name\n"
-                        + "passwordEnvVariable: PASS_ENV\n"
-                        + "passwordFile: ~/p.conf\n"
                         + "labelsFile: ~/l.conf\n"
                         + "pidFile: ~/s.pid\n"
                         + "prometheusPort: 112233\n";
@@ -55,26 +39,10 @@ public class YamlConfigTest {
         assertThat(options.description, equalTo("Configured from yml"));
         assertThat(options.executors, equalTo(3));
         assertThat(options.labels, hasItems("label-a", "label-b", "label-c"));
-        assertThat(options.webSocket, equalTo(true));
         assertThat(options.disableClientsUniqueId, equalTo(true));
         assertThat(options.mode, equalTo(ModeOptionHandler.EXCLUSIVE));
-        assertThat(options.retry, equalTo(0));
         assertThat(options.failIfWorkDirIsMissing, equalTo(false));
-        assertThat(options.toolLocations.size(), equalTo(2));
-        assertThat(options.toolLocations.get("tool-a"), equalTo("/tool/path/a"));
-        assertThat(options.toolLocations.get("tool-b"), equalTo("/tool/path/b"));
-        assertThat(options.noRetryAfterConnected, equalTo(true));
-        assertThat(options.environmentVariables.size(), equalTo(2));
-        assertThat(options.environmentVariables.get("ENV_1"), equalTo("env#1"));
-        assertThat(options.environmentVariables.get("ENV_2"), equalTo("env#2"));
-        assertThat(options.retryInterval, equalTo(12));
-        assertThat(options.maxRetryInterval, equalTo(9));
-        assertThat(options.disableSslVerification, equalTo(false));
-        assertThat(options.sslFingerprints, equalTo("fp0 fp1 fp2"));
         assertThat(options.deleteExistingClients, equalTo(true));
-        assertThat(options.username, equalTo("swarm-user-name"));
-        assertThat(options.passwordEnvVariable, equalTo("PASS_ENV"));
-        assertThat(options.passwordFile, equalTo("~/p.conf"));
         assertThat(options.labelsFile, equalTo("~/l.conf"));
         assertThat(options.pidFile, equalTo("~/s.pid"));
         assertThat(options.prometheusPort, equalTo(112233));
@@ -98,6 +66,78 @@ public class YamlConfigTest {
                                 fail(e.getMessage());
                             }
                         });
+    }
+
+    @Test
+    public void toolLocationOption() throws ConfigurationException {
+        final String yamlString =
+                "url: http://localhost:8080/jenkins\n"
+                        + "toolLocations:\n"
+                        + "  tool-a: /tool/path/a\n"
+                        + "  tool-b: /tool/path/b\n"
+                        + "  ENV_2: env#2\n";
+
+        final Options options = loadYaml(yamlString);
+        assertThat(options.toolLocations.get("tool-a"), equalTo("/tool/path/a"));
+        assertThat(options.toolLocations.get("tool-b"), equalTo("/tool/path/b"));
+    }
+
+    @Test
+    public void errorHandlingOptions() throws ConfigurationException {
+        final String yamlString =
+                "url: http://localhost:8080/jenkins\n"
+                        + "retry: 0\n"
+                        + "noRetryAfterConnected: true\n"
+                        + "retryInterval: 12\n"
+                        + "maxRetryInterval: 9\n";
+
+        final Options options = loadYaml(yamlString);
+        assertThat(options.url, equalTo("http://localhost:8080/jenkins"));
+        assertThat(options.retry, equalTo(0));
+        assertThat(options.failIfWorkDirIsMissing, equalTo(false));
+        assertThat(options.noRetryAfterConnected, equalTo(true));
+        assertThat(options.retryInterval, equalTo(12));
+        assertThat(options.maxRetryInterval, equalTo(9));
+    }
+
+    @Test
+    public void environmentVariablesOption() throws ConfigurationException {
+        final String yamlString =
+                "url: http://localhost:8080/jenkins\n"
+                        + "environmentVariables:\n"
+                        + "  ENV_1: env#1\n"
+                        + "  ENV_2: env#2\n";
+
+        final Options options = loadYaml(yamlString);
+        assertThat(options.environmentVariables.get("ENV_1"), equalTo("env#1"));
+        assertThat(options.environmentVariables.get("ENV_2"), equalTo("env#2"));
+    }
+
+    @Test
+    public void authenticationOptions() throws ConfigurationException {
+        final String yamlString =
+                "url: http://localhost:8080/jenkins\n"
+                        + "disableSslVerification: false\n"
+                        + "sslFingerprints: fp0 fp1 fp2\n"
+                        + "username: swarm-user-name\n"
+                        + "passwordEnvVariable: PASS_ENV\n"
+                        + "passwordFile: ~/p.conf\n";
+
+        final Options options = loadYaml(yamlString);
+        assertThat(options.url, equalTo("http://localhost:8080/jenkins"));
+        assertThat(options.disableSslVerification, equalTo(false));
+        assertThat(options.sslFingerprints, equalTo("fp0 fp1 fp2"));
+        assertThat(options.username, equalTo("swarm-user-name"));
+        assertThat(options.passwordEnvVariable, equalTo("PASS_ENV"));
+        assertThat(options.passwordFile, equalTo("~/p.conf"));
+    }
+
+    @Test
+    public void webSocketOptions() throws ConfigurationException {
+        final String yamlString = "url: http://localhost:8080/jenkins\n" + "webSocket: true\n";
+
+        final Options options = loadYaml(yamlString);
+        assertThat(options.webSocket, equalTo(true));
     }
 
     @Test

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -48,6 +48,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -240,7 +241,7 @@ public class SwarmClientIntegrationTest {
     @Test
     @Issue("JENKINS-61969")
     public void webSocket() throws Exception {
-        Assume.assumeTrue(Jenkins.getVersion().isNewerThanOrEqualTo(new VersionNumber("2.222.4")));
+        Assume.assumeTrue(hasWebSocketSupport());
         Node node = swarmClientRule.createSwarmClient("-webSocket");
 
         FreeStyleProject project = j.createFreeStyleProject();
@@ -250,6 +251,26 @@ public class SwarmClientIntegrationTest {
 
         FreeStyleBuild build = j.buildAndAssertSuccess(project);
         j.assertLogContains("ON_SWARM_CLIENT=true", build);
+    }
+
+    @Test
+    public void webSocketHeaders() throws IOException, InterruptedException {
+        Assume.assumeTrue(hasWebSocketSupport());
+        swarmClientRule.createSwarmClient(
+                "-webSocket", "-webSocketHeader", "WS_HEADER=HEADER_VALUE");
+    }
+
+    @Test
+    public void webSocketHeadersFailsIfNoWebSocketArgument()
+            throws IOException, InterruptedException {
+        Assume.assumeTrue(hasWebSocketSupport());
+        startFailingSwarmClient(
+                j.getURL(), "should_fail", "-webSocketHeader", "WS_HEADER=HEADER_VALUE");
+    }
+
+    private boolean hasWebSocketSupport() {
+        return Objects.requireNonNull(Jenkins.getVersion())
+                .isNewerThanOrEqualTo(new VersionNumber("2.222.4"));
     }
 
     @Test


### PR DESCRIPTION
Support for `-webSocketHeader`, as added in remoting v4.9 (https://github.com/jenkinsci/remoting/pull/458).

The _remoting_ update has been merged already ( #332).

Tests are available for CLI and Yaml option handling, but I haven't figured out how to get tests of the actual websocket headers used into `SwarmClientIntegrationTest` – suggestions welcome.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
