### PR TITLE
Fix fsroot option name when used in YAML config file

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -24,7 +24,7 @@ public class Options {
     public List<String> labels = new ArrayList<>();
 
     @Option(name = "-fsroot", usage = "Remote root directory.")
-    public File remoteFsRoot = new File(".");
+    public File fsroot = new File(".");
 
     @Option(name = "-executors", usage = "Number of executors")
     public int executors = Runtime.getRuntime().availableProcessors();

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -101,7 +101,7 @@ public class SwarmClient {
     public SwarmClient(Options options) {
         this.options = options;
         if (!options.disableClientsUniqueId) {
-            this.hash = hash(options.remoteFsRoot);
+            this.hash = hash(options.fsroot);
         } else {
             this.hash = "";
         }
@@ -223,7 +223,7 @@ public class SwarmClient {
             String workDirPath =
                     options.workDir != null
                             ? options.workDir.getPath()
-                            : options.remoteFsRoot.getPath();
+                            : options.fsroot.getPath();
             args.add("-workDir");
             args.add(workDirPath);
 
@@ -434,7 +434,7 @@ public class SwarmClient {
                                 + options.name
                                 + "&executors="
                                 + options.executors
-                                + param("remoteFsRoot", options.remoteFsRoot.getAbsolutePath())
+                                + param("remoteFsRoot", options.fsroot.getAbsolutePath())
                                 + param("description", options.description)
                                 + param("labels", sMyLabels)
                                 + toolLocationBuilder


### PR DESCRIPTION
Previously, this was the only option which had an internal variable
name which differed from the exposed option name. This could be
confusing for users wanting to use the new YAML config file format,
since it meant that they would need to specify `remoteFsRoot` there,
and look at the source code to figure out this option name.

<!-- Please describe your pull request here. -->

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] ~Link to relevant issues in GitHub or Jira~
- [X] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
