### PR TITLE
Case insensitive YAML enums

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/YamlConfig.java
+++ b/client/src/main/java/hudson/plugins/swarm/YamlConfig.java
@@ -1,6 +1,7 @@
 package hudson.plugins.swarm;
 
 import org.kohsuke.args4j.Option;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -14,7 +15,9 @@ public class YamlConfig {
     private final Yaml yaml;
 
     public YamlConfig() {
-        this.yaml = new Yaml(new Constructor(Options.class));
+        final LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setEnumCaseSensitive(false);
+        this.yaml = new Yaml(new Constructor(Options.class, loaderOptions));
     }
 
     public Options loadOptions(InputStream inputStream) throws ConfigurationException {

--- a/client/src/test/java/hudson/plugins/swarm/YamlConfigTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/YamlConfigTest.java
@@ -201,6 +201,18 @@ public class YamlConfigTest {
     }
 
     @Test
+    public void enumsAreCaseInsensitive() throws ConfigurationException {
+        final Options upperCase = loadYaml("url: ignore\nretryBackOffStrategy: LINEAR\n");
+        assertThat(upperCase.retryBackOffStrategy, equalTo(RetryBackOffStrategy.LINEAR));
+
+        final Options lowerCase = loadYaml("url: ignore\nretryBackOffStrategy: exponential\n");
+        assertThat(lowerCase.retryBackOffStrategy, equalTo(RetryBackOffStrategy.EXPONENTIAL));
+
+        final Options mixedCase = loadYaml("url: ignore\nretryBackOffStrategy: eXPONenTiaL\n");
+        assertThat(mixedCase.retryBackOffStrategy, equalTo(RetryBackOffStrategy.EXPONENTIAL));
+    }
+
+    @Test
     public void failsIfDeprecatedOptionIsUsed() {
         final Throwable ex =
                 assertThrows(


### PR DESCRIPTION
SnakeYaml 1.28 has added support for case insensitive enums recently.

```yml
...
retryBackOffStrategy: LINEAR # Still ok
retryBackOffStrategy: linear # Ok too now
retryBackOffStrategy: LinEAr # ( Ok too now )
...
```
All caps entries are avoidable now. I don't think there's any drawback, since the values must stay within the valid enums as before.  

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] ~~Link to relevant issues in GitHub or Jira~~
- [x] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
