### PR TITLE
Fix: Remove prefixed `/` from url path when getting agent labels to prevent malformed URL error

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -79,7 +79,7 @@ public class LabelFileWatcher implements Runnable {
 
         Document xml;
 
-        HttpGet get = new HttpGet(url + "/plugin/swarm/getSlaveLabels?name=" + name);
+        HttpGet get = new HttpGet(url + "plugin/swarm/getSlaveLabels?name=" + name);
         try (CloseableHttpResponse response = client.execute(get, context)) {
             if (response.getCode() != HttpStatus.SC_OK) {
                 logger.log(


### PR DESCRIPTION
The `url` variable has a forward slash appended to it during the configuration loading.

This causes an issue later on when fetching the agent's labels because the uri path includes a forward slash here as well. This causes the following code in [httpcomponents](https://github.com/apache/httpcomponents-core/blob/6d2297fbee986a0209f60d861033156b72d82dbf/httpcore5/src/main/java/org/apache/hc/core5/http/message/BasicHttpRequest.java#L281) to be hit

This aligns with the other `HttpGet(url + ` calls within the code base. 

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
