### PR TITLE
Feat: Allows users to opt out of the agent node removal process on the controller

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Options.java
+++ b/client/src/main/java/hudson/plugins/swarm/Options.java
@@ -113,6 +113,11 @@ public class Options {
     public boolean deleteExistingClients;
 
     @Option(
+            name = "-keepDisconnectedClients",
+            usage = "Do not remove clients from the controller when the agent becomes disconnected.")
+    public boolean keepDisconnectedClients;
+
+    @Option(
             name = "-mode",
             usage =
                     "The mode controlling how Jenkins allocates jobs to agents. Can be either '"

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -444,7 +444,10 @@ public class SwarmClient {
                                 + param("hash", hash)
                                 + param(
                                         "deleteExistingClients",
-                                        Boolean.toString(options.deleteExistingClients)));
+                                        Boolean.toString(options.deleteExistingClients))
+                                + param("keepDisconnectedClients",
+                                        Boolean.toString(options.keepDisconnectedClients))
+                );
 
         post.addHeader(HttpHeaders.CONNECTION, "close");
 

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -445,9 +445,9 @@ public class SwarmClient {
                                 + param(
                                         "deleteExistingClients",
                                         Boolean.toString(options.deleteExistingClients))
-                                + param("keepDisconnectedClients",
-                                        Boolean.toString(options.keepDisconnectedClients))
-                );
+                                + param(
+                                        "keepDisconnectedClients",
+                                        Boolean.toString(options.keepDisconnectedClients)));
 
         post.addHeader(HttpHeaders.CONNECTION, "close");
 

--- a/client/src/test/java/hudson/plugins/swarm/YamlConfigTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/YamlConfigTest.java
@@ -30,6 +30,7 @@ public class YamlConfigTest {
                         + "mode: exclusive\n"
                         + "failIfWorkDirIsMissing: false\n"
                         + "deleteExistingClients: true\n"
+                        + "keepDisconnectedClients: false\n"
                         + "labelsFile: ~/l.conf\n"
                         + "pidFile: ~/s.pid\n"
                         + "prometheusPort: 112233\n";
@@ -43,6 +44,7 @@ public class YamlConfigTest {
         assertThat(options.mode, equalTo(ModeOptionHandler.EXCLUSIVE));
         assertThat(options.failIfWorkDirIsMissing, equalTo(false));
         assertThat(options.deleteExistingClients, equalTo(true));
+        assertThat(options.keepDisconnectedClients, equalTo(false));
         assertThat(options.labelsFile, equalTo("~/l.conf"));
         assertThat(options.pidFile, equalTo("~/s.pid"));
         assertThat(options.prometheusPort, equalTo(112233));

--- a/plugin/src/main/java/hudson/plugins/swarm/KeepSwarmClientNodeProperty.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/KeepSwarmClientNodeProperty.java
@@ -1,10 +1,10 @@
 package hudson.plugins.swarm;
 
+import hudson.Extension;
+import hudson.model.Node;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 
-import hudson.Extension;
-import hudson.model.Node;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -14,11 +14,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @since 1.286
  */
 public class KeepSwarmClientNodeProperty extends NodeProperty<Node> {
-    
+
     @DataBoundConstructor
-    public KeepSwarmClientNodeProperty() { }
-	
-    @Extension @Symbol("keepSwarmClient")
+    public KeepSwarmClientNodeProperty() {}
+
+    @Extension
+    @Symbol("keepSwarmClient")
     public static class DescriptorImpl extends NodePropertyDescriptor {
 
         @Override

--- a/plugin/src/main/java/hudson/plugins/swarm/KeepSwarmClientNodeProperty.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/KeepSwarmClientNodeProperty.java
@@ -1,0 +1,29 @@
+package hudson.plugins.swarm;
+
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
+
+import hudson.Extension;
+import hudson.model.Node;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * {@link NodeProperty} that sets additional environment variables.
+ *
+ * @since 1.286
+ */
+public class KeepSwarmClientNodeProperty extends NodeProperty<Node> {
+    
+    @DataBoundConstructor
+    public KeepSwarmClientNodeProperty() { }
+	
+    @Extension @Symbol("keepSwarmClient")
+    public static class DescriptorImpl extends NodePropertyDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return "Keep Swarm client node after agent disconnect";
+        }
+    }
+}

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -172,7 +172,7 @@ public class PluginImpl extends Plugin {
         }
 
         // We use the existance of the node property itself as the boolean flag
-        if(keepDisconnectedClients) {
+        if (keepDisconnectedClients) {
             nodeProperties.add(new KeepSwarmClientNodeProperty());
         }
 

--- a/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/PluginImpl.java
@@ -149,7 +149,8 @@ public class PluginImpl extends Plugin {
             @QueryParameter String labels,
             @QueryParameter Node.Mode mode,
             @QueryParameter(fixEmpty = true) String hash,
-            @QueryParameter boolean deleteExistingClients)
+            @QueryParameter boolean deleteExistingClients,
+            @QueryParameter boolean keepDisconnectedClients)
             throws IOException {
         Jenkins jenkins = Jenkins.get();
 
@@ -168,6 +169,11 @@ public class PluginImpl extends Plugin {
             List<EnvironmentVariablesNodeProperty.Entry> parsedEnvironmentVariables =
                     parseEnvironmentVariables(environmentVariables);
             nodeProperties.add(new EnvironmentVariablesNodeProperty(parsedEnvironmentVariables));
+        }
+
+        // We use the existance of the node property itself as the boolean flag
+        if(keepDisconnectedClients) {
+            nodeProperties.add(new KeepSwarmClientNodeProperty());
         }
 
         if (hash == null && jenkins.getNode(name) != null && !deleteExistingClients) {

--- a/plugin/src/main/java/hudson/plugins/swarm/SwarmLauncher.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/SwarmLauncher.java
@@ -24,6 +24,9 @@ import java.io.IOException;
  */
 public class SwarmLauncher extends JNLPLauncher {
 
+    // Property name: `hudson.plugins.swarm.SwarmLauncher.removeAfterDisconnect`
+    private boolean removeAfterDisconnect = Boolean.parseBoolean(System.getProperty(SwarmLauncher.class.getName() + ".removeAfterDisconnect", "true"));
+
     public SwarmLauncher() {
         super(false);
     }
@@ -31,6 +34,13 @@ public class SwarmLauncher extends JNLPLauncher {
     @Override
     public void afterDisconnect(SlaveComputer computer, TaskListener listener) {
         super.afterDisconnect(computer, listener);
+
+        // Don't remove the node object if we've disconnected
+        if(!removeAfterDisconnect) {
+            listener.getLogger()
+                    .printf("Skipping removal of Node for computer \"%s\".%n", computer);
+            return;
+        }
 
         Slave node = computer.getNode();
         if (node != null) {

--- a/plugin/src/main/java/hudson/plugins/swarm/SwarmLauncher.java
+++ b/plugin/src/main/java/hudson/plugins/swarm/SwarmLauncher.java
@@ -17,7 +17,6 @@ import jenkins.slaves.DefaultJnlpSlaveReceiver;
 import org.jenkinsci.remoting.engine.JnlpConnectionState;
 
 import java.io.IOException;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -41,21 +40,28 @@ public class SwarmLauncher extends JNLPLauncher {
         if (node != null) {
             String nodeName = node.getNodeName();
             try {
-                // Don't remove the node object if we've disconnected, if the node doesn't want to be removed
-                KeepSwarmClientNodeProperty keepClientProp = node.getNodeProperty(KeepSwarmClientNodeProperty.class);
-                
+                // Don't remove the node object if we've disconnected, if the node doesn't want to
+                // be removed
+                KeepSwarmClientNodeProperty keepClientProp =
+                        node.getNodeProperty(KeepSwarmClientNodeProperty.class);
+
                 // We use the existance of the node property on the node itself as a boolean check
-                if(keepClientProp == null) {
+                if (keepClientProp == null) {
                     LOGGER.log(Level.INFO, "Removing Swarm Node for computer [{0}]", nodeName);
                     Jenkins.get().removeNode(node);
                 } else {
-                    listener.getLogger().printf("Skipping removal of Node for computer [%1$s]", nodeName);
+                    listener.getLogger()
+                            .printf("Skipping removal of Node for computer [%1$s]", nodeName);
                     LOGGER.log(Level.INFO, "Skipping removal of Node for computer [{0}]", nodeName);
                 }
             } catch (IOException e) {
                 Functions.printStackTrace(
                         e, listener.error("Failed to remove node [%1$s]", nodeName));
-                LOGGER.log(Level.WARNING, String.format("Failed to remove node [%1$s] %n%2$s", nodeName, Functions.printThrowable(e).trim()));
+                LOGGER.log(
+                        Level.WARNING,
+                        String.format(
+                                "Failed to remove node [%1$s] %n%2$s",
+                                nodeName, Functions.printThrowable(e).trim()));
             }
         } else {
             listener.getLogger()

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import hudson.Functions;
-import hudson.model.Computer;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
@@ -638,19 +637,20 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void keepDisconnectedClients() throws Exception {
-        SwarmSlave swarmNode = (SwarmSlave)swarmClientRule.createSwarmClientWithName(
-            "keepagent",
-            "-keepDisconnectedClients",
-            "-deleteExistingClients",
-            "-disableClientsUniqueId"
-        );
+        SwarmSlave swarmNode =
+                (SwarmSlave)
+                        swarmClientRule.createSwarmClientWithName(
+                                "keepagent",
+                                "-keepDisconnectedClients",
+                                "-deleteExistingClients",
+                                "-disableClientsUniqueId");
 
         assertNotNull(swarmNode);
         assertNotNull(swarmNode.getNodeProperty(KeepSwarmClientNodeProperty.class));
-        
+
         swarmClientRule.tearDown();
 
-        //Check that the agent was not removed
+        // Check that the agent was not removed
         Node node = j.getInstance().getNode("keepagent");
         assertNotNull(node);
 
@@ -663,23 +663,21 @@ public class SwarmClientIntegrationTest {
 
     @Test
     public void removeDisconnectedClients() throws Exception {
-        SwarmSlave swarmNode = (SwarmSlave)swarmClientRule.createSwarmClientWithName(
-            "deleteagent",
-            "-deleteExistingClients",
-            "-disableClientsUniqueId"
-        );
+        SwarmSlave swarmNode =
+                (SwarmSlave)
+                        swarmClientRule.createSwarmClientWithName(
+                                "deleteagent", "-deleteExistingClients", "-disableClientsUniqueId");
 
         assertNotNull(swarmNode);
         assertNull(swarmNode.getNodeProperty(KeepSwarmClientNodeProperty.class));
 
         swarmClientRule.tearDown();
 
-        //Check that the agent was successfully removed
+        // Check that the agent was successfully removed
         Node node = j.getInstance().getNode("deleteagent");
         assertNull(node);
 
         // Verify the cleanup worked
         assertEquals(j.getInstance().getNodes().size(), 0);
-        
     }
 }

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -3,9 +3,11 @@ package hudson.plugins.swarm;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import hudson.Functions;
+import hudson.model.Computer;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
@@ -632,5 +634,52 @@ public class SwarmClientIntegrationTest {
         assertTrue(process.waitFor(30, TimeUnit.SECONDS));
         assertFalse(process.isAlive());
         assertEquals(1, process.exitValue());
+    }
+
+    @Test
+    public void keepDisconnectedClients() throws Exception {
+        SwarmSlave swarmNode = (SwarmSlave)swarmClientRule.createSwarmClientWithName(
+            "keepagent",
+            "-keepDisconnectedClients",
+            "-deleteExistingClients",
+            "-disableClientsUniqueId"
+        );
+
+        assertNotNull(swarmNode);
+        assertNotNull(swarmNode.getNodeProperty(KeepSwarmClientNodeProperty.class));
+        
+        swarmClientRule.tearDown();
+
+        //Check that the agent was not removed
+        Node node = j.getInstance().getNode("keepagent");
+        assertNotNull(node);
+
+        // Properly cleanup everything
+        swarmClientRule.tearDownAll();
+
+        // Verify the cleanup worked
+        assertEquals(j.getInstance().getNodes().size(), 0);
+    }
+
+    @Test
+    public void removeDisconnectedClients() throws Exception {
+        SwarmSlave swarmNode = (SwarmSlave)swarmClientRule.createSwarmClientWithName(
+            "deleteagent",
+            "-deleteExistingClients",
+            "-disableClientsUniqueId"
+        );
+
+        assertNotNull(swarmNode);
+        assertNull(swarmNode.getNodeProperty(KeepSwarmClientNodeProperty.class));
+
+        swarmClientRule.tearDown();
+
+        //Check that the agent was successfully removed
+        Node node = j.getInstance().getNode("deleteagent");
+        assertNull(node);
+
+        // Verify the cleanup worked
+        assertEquals(j.getInstance().getNodes().size(), 0);
+        
     }
 }

--- a/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
@@ -340,7 +340,7 @@ public class SwarmClientRule extends ExternalResource {
      * the final agent name, so we have to keep iterating until we find the agent that starts with
      * the proposed name.
      */
-    public synchronized Computer getComputer(String agentName) {
+    private Computer getComputer(String agentName) {
         List<Computer> candidates = new ArrayList<>();
         for (Computer candidate : j.get().jenkins.getComputers()) {
             if (candidate.getName().equals(agentName)) {

--- a/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
@@ -459,7 +459,7 @@ public class SwarmClientRule extends ExternalResource {
                 j.get().jenkins.removeNode(comp.getNode());
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
@@ -455,7 +455,7 @@ public class SwarmClientRule extends ExternalResource {
         }
 
         try {
-            for(Computer comp : j.get().jenkins.getComputers()) {
+            for (Computer comp : j.get().jenkins.getComputers()) {
                 j.get().jenkins.removeNode(comp.getNode());
             }
         } catch (IOException e) {

--- a/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
@@ -340,7 +340,7 @@ public class SwarmClientRule extends ExternalResource {
      * the final agent name, so we have to keep iterating until we find the agent that starts with
      * the proposed name.
      */
-    private Computer getComputer(String agentName) {
+    public synchronized Computer getComputer(String agentName) {
         List<Computer> candidates = new ArrayList<>();
         for (Computer candidate : j.get().jenkins.getComputers()) {
             if (candidate.getName().equals(agentName)) {

--- a/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/test/SwarmClientRule.java
@@ -448,6 +448,21 @@ public class SwarmClientRule extends ExternalResource {
         }
     }
 
+    public synchronized void tearDownAll() {
+        if (isActive) {
+            throw new IllegalStateException(
+                    "Must be called after a tearDown() to fully clean up disconnected nodes");
+        }
+
+        try {
+            for(Computer comp : j.get().jenkins.getComputers()) {
+                j.get().jenkins.removeNode(comp.getNode());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
     /** Override to tear down your specific external resource. */
     @Override
     protected synchronized void after() {


### PR DESCRIPTION
Exposes a system property (`hudson.plugins.swarm.SwarmLauncher.removeAfterDisconnect`) that allows users to opt out of the agent node removal process. 

This allows users to utilize the auto-configuration aspect of the swarm plugin, while enabling them to have visibility into disconnected agents.

Ideally users would use this functionality on the controller in conjunction with the `-deleteExistingClients` on the client (assuming `-disableClientsUniqueId` is also used) 

The code defaults to retaining the existing functionality and removes agent nodes from the controller on agent disconnect.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

