### PR TITLE
Bump oshi-core dependency to 6.1.5, to fix behavior on illumos

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
-            <version>6.1.4</version>
+            <version>6.1.5</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>com.github.oshi</groupId>
             <artifactId>oshi-core</artifactId>
-            <version>6.1.4</version>
+            <version>6.1.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
update pom.xml reference to oshi-core version 6.1.5, which should detect the OS differently and not assume that everything "SunOS" is Solaris 11.4+ with its new native kstat2 shared-object library

More context details at:
https://github.com/oshi/oshi/pull/1966
https://github.com/oshi/oshi/pull/1977


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
