### PR TITLE
SwarmClient.java: properly process labelFile which is not a single line

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -135,6 +135,12 @@ public class SwarmClient {
         return name;
     }
 
+    public List<String> getOptionsLabels() {
+        /* Note: these labels might differ from run-time values assigned
+         * to an actual agent, if someone edits it via configure page */
+        return options.labels;
+    }
+
     public URL getUrl() {
         logger.config("getUrl() invoked");
 

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -115,13 +115,11 @@ public class SwarmClient {
                         new String(
                                 Files.readAllBytes(Paths.get(options.labelsFile)),
                                 StandardCharsets.UTF_8);
-                options.labels.addAll(Arrays.asList(labels.split(" ")));
+                options.labels.addAll(Arrays.asList(labels.trim().split("\\s+")));
                 logger.info("Labels found in file: " + labels);
                 logger.info(
                         "Effective label list: "
-                                + Arrays.toString(options.labels.toArray())
-                                        .replaceAll("\n", "")
-                                        .replaceAll("\r", ""));
+                                + Arrays.toString(options.labels.toArray()));
             } catch (IOException e) {
                 throw new UncheckedIOException(
                         "Problem reading labels from file " + options.labelsFile, e);

--- a/client/src/test/java/hudson/plugins/swarm/SwarmClientTest.java
+++ b/client/src/test/java/hudson/plugins/swarm/SwarmClientTest.java
@@ -1,13 +1,26 @@
 package hudson.plugins.swarm;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
 public class SwarmClientTest {
+
+    @ClassRule(order = 20)
+    public static TemporaryFolder temporaryFolder = TemporaryFolder.builder().assureDeletion().build();
 
     @Test
     public void should_create_instance_on_default_options() {
@@ -22,5 +35,105 @@ public class SwarmClientTest {
         try (CloseableHttpClient client = SwarmClient.createHttpClient(options)) {
             assertNotNull(client);
         }
+    }
+
+    /* Below we have a series of tests which make sure that different ways
+     * of passing labels (usually via labelsFile) end up with a sane set.
+     * Customized options may be provided to test e.g. concatenation of
+     * label sets passed explicitly and by file.
+     * See PR https://github.com/jenkinsci/swarm-plugin/pull/420 for how
+     * this parsing misbehaved earlier.
+     */
+    private static void test_labelsFile(String labelsToAdd, String... expected) throws IOException {
+        test_labelsFile(null, labelsToAdd, expected);
+    }
+
+    private static void test_labelsFile(Options options, String labelsToAdd, String... expected) throws IOException {
+        Path labelsFile =
+                Files.createTempFile(temporaryFolder.getRoot().toPath(), "labelsFile", ".txt");
+
+        try (Writer writer = Files.newBufferedWriter(labelsFile, StandardCharsets.UTF_8)) {
+            writer.write(labelsToAdd);
+        }
+
+        if (options == null)
+            options = new Options();
+
+        options.labelsFile = labelsFile.toString();
+
+        SwarmClient swc = new SwarmClient(options);
+        assertNotNull(swc);
+
+        List<String> labels = swc.getOptionsLabels();
+        assertNotNull(labels);
+
+        /* Exactly same amount of entries as expected */
+        /* import of containsInAnyOrder failed for me, so...
+         * assertThat(labels, containsInAnyOrder(expected)); */
+        assertThat(labels, hasItems(expected));
+        assertEquals(labels.size(), expected.length);
+
+        Files.delete(labelsFile);
+    }
+
+    @Test
+    public void parse_options_separated_by_spaces() throws IOException {
+        String labelsFileContent = "COMPILER=GCC COMPILER=CLANG ARCH64=amd64 ARCH32=i386";
+        test_labelsFile(labelsFileContent, "COMPILER=GCC", "COMPILER=CLANG", "ARCH64=amd64", "ARCH32=i386");
+    }
+
+    @Test
+    public void parse_options_surrounded_by_spaces() throws IOException {
+        String labelsFileContent = "  COMPILER=GCC COMPILER=CLANG ARCH64=amd64 ARCH32=i386 ";
+        test_labelsFile(labelsFileContent, "COMPILER=GCC", "COMPILER=CLANG", "ARCH64=amd64", "ARCH32=i386");
+    }
+
+    @Test
+    public void parse_options_separated_by_tabs_and_eols() throws IOException {
+        String labelsFileContent =
+            "  COMPILER=GCC\n" +
+            " COMPILER=CLANG\tARCH64=amd64 \n" +
+            " ARCH32=i386 \n";
+        test_labelsFile(labelsFileContent, "COMPILER=GCC", "COMPILER=CLANG", "ARCH64=amd64", "ARCH32=i386");
+    }
+
+    @Test
+    public void parse_options_multiline_indented_all() throws IOException {
+        String labelsFileContent =
+            " COMPILER=GCC\n" +
+            " COMPILER=CLANG\n" +
+            " ARCH64=amd64\n" +
+            " ARCH32=i386\n";
+        test_labelsFile(labelsFileContent, "COMPILER=GCC", "COMPILER=CLANG", "ARCH64=amd64", "ARCH32=i386");
+    }
+
+    @Test
+    public void parse_options_multiline_indented_all_but_first() throws IOException {
+        String labelsFileContent =
+            "COMPILER=GCC\n" +
+            " COMPILER=CLANG\n" +
+            " ARCH64=amd64\n" +
+            " ARCH32=i386\n";
+        test_labelsFile(labelsFileContent, "COMPILER=GCC", "COMPILER=CLANG", "ARCH64=amd64", "ARCH32=i386");
+    }
+
+    @Test
+    public void parse_options_multiline_not_indented() throws IOException {
+        String labelsFileContent =
+            "COMPILER=GCC\n" +
+            "COMPILER=CLANG\n" +
+            "ARCH64=amd64\n" +
+            "ARCH32=i386\n";
+        test_labelsFile(labelsFileContent, "COMPILER=GCC", "COMPILER=CLANG", "ARCH64=amd64", "ARCH32=i386");
+    }
+
+    @Test
+    public void parse_options_multiline_trailins_whitespace() throws IOException {
+        String labelsFileContent =
+            "COMPILER=GCC\t\n" +
+            "COMPILER=CLANG \n" +
+            "ARCH64=amd64  \n\n" +
+            "ARCH32=i386\n";
+        test_labelsFile(labelsFileContent, "COMPILER=GCC", "COMPILER=CLANG", "ARCH64=amd64", "ARCH32=i386");
     }
 }


### PR DESCRIPTION
…with surrounding whitespace (indentation) or multiple lines

Context:

I was setting up a new worker with a label file, which I nicely formatted as one label (KEY=VALUE) per line, trusting the docs about whitespace-separated labels. An annoying or outright toxic behavior in previous releases of swarm-client including 2.31 was found, that this file effectively got concatenated into a huge line (`KEY1=VAL1KEY2=VAL2...`), at least as seen in `$JENKINS_URL/computers/agentname/configure` and that chunk comes into effect at least if that interactive config page gets "saved". Seems the bogus string is not misfiring immediately after load though, the main page of `$JENKINS_URL/computers/agentname` just after agent connection showed numerous labels.

Example label file (only end-of-lines as whitespace):
````
COMPILER=GCC
COMPILER=CLANG
ARCH64=amd64
ARCH32=i386
````

Example log from swarm agent 2.31 startup:
````
...
Mar 17, 2022 2:48:54 PM hudson.plugins.swarm.SwarmClient <init>
INFO: Labels found in file: COMPILER=GCC
COMPILER=CLANG
ARCH64=amd64
ARCH32=i386

Mar 17, 2022 2:48:54 PM hudson.plugins.swarm.SwarmClient <init>
INFO: Effective label list: [COMPILER=GCCCOMPILER=CLANGARCH64=amd64ARCH32=i386]
Mar 17, 2022 2:48:54 PM hudson.plugins.swarm.Client run
...
````

Then I fixed up the labels file, as I did some years ago in other installations, to prefix each line with a space:
````
 COMPILER=GCC
 COMPILER=CLANG
 ARCH64=amd64
 ARCH32=i386
````

This got me a label list with an empty entry, but otherwise with separated tokens:
````
INFO: Labels found in file:  COMPILER=GCC
 COMPILER=CLANG
 ARCH64=amd64
 ARCH32=i386
INFO: Effective label list: [, COMPILER=GCC, COMPILER=CLANG, ARCH64=amd64, ARCH32=i386]
````

Not-indenting just the first line does help avoid the empty entry, but is clumsy to automate in start-up scriptware :)

Finally, with this PR in place to split not by exactly space chars (and later strip end of lines), but by whitespace chars as documented and as done elsewhere in code (LabelFile watcher), after trimming the original string, I got the expected effect for both indented and non-indented multiline label files, including lines with several labels separated by spaces and tab characters:
````
INFO: Effective label list: [COMPILER=GCC, COMPILER=CLANG, ARCH64=amd64, ARCH32=i386]
````

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
