### PR TITLE
[JENKINS-69575] Fix SLF4J configuration

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -26,7 +26,6 @@
         <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <slf4j.version>2.0.0</slf4j.version>
         <spotbugs.excludeFilterFile>${project.basedir}/../src/spotbugs/excludesFilter.xml</spotbugs.excludeFilterFile>
     </properties>
 
@@ -75,10 +74,6 @@
                                     <pattern>org.apache</pattern>
                                     <shadedPattern>shaded.org.apache</shadedPattern>
                                 </relocation>
-                                <relocation>
-                                    <pattern>org.slf4j</pattern>
-                                    <shadedPattern>shaded.org.slf4j</shadedPattern>
-                                </relocation>
                             </relocations>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
@@ -105,20 +100,9 @@
             <version>2.33</version>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
-            <scope>provided</scope><!-- by jcl-over-slf4j -->
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>${slf4j.version}</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>


### PR DESCRIPTION
The shading of SLF4J was breaking SLF4J's JPMS support introduced in SLF4J 2.x. While we were here, we removed the `commons-logging` bridge, which had only been added previously to support Apache HttpComponents 4.x, which we no longer use. Apache HttpComponents 5.x uses SLF4J natively without the need for `commons-logging`.