### PR TITLE
Check path of old PID (if running) before exiting

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -117,7 +117,7 @@ public class Client {
                                                     + " running.",
                                             pidFile.toAbsolutePath(),
                                             oldPid,
-                                            oldProcess.get().info().commandLine().orElse("")));
+                                            oldProcess.get().info().commandLine().orElse("unknown")));
                         } else {
                             logger.fine(
                                     String.format(

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -117,7 +117,11 @@ public class Client {
                                                     + " running.",
                                             pidFile.toAbsolutePath(),
                                             oldPid,
-                                            oldProcess.get().info().commandLine().orElse("unknown")));
+                                            oldProcess
+                                                    .get()
+                                                    .info()
+                                                    .commandLine()
+                                                    .orElse("unknown")));
                         } else {
                             logger.fine(
                                     String.format(

--- a/client/src/main/java/hudson/plugins/swarm/Client.java
+++ b/client/src/main/java/hudson/plugins/swarm/Client.java
@@ -123,11 +123,17 @@ public class Client {
                                                     .commandLine()
                                                     .orElse("unknown")));
                         } else {
-                            logger.fine(
+                            logger.warning(
                                     String.format(
-                                            "Ignoring stale PID file '%s' because the process %d is"
-                                                    + " not a Swarm Client.",
-                                            pidFile.toAbsolutePath(), oldPid));
+                                            "Ignoring stale PID file '%s' because the process %d"
+                                                + " (%s) is not a Swarm Client.",
+                                            pidFile.toAbsolutePath(),
+                                            oldPid,
+                                            oldProcess
+                                                    .get()
+                                                    .info()
+                                                    .commandLine()
+                                                    .orElse("unknown")));
                         }
                     } else {
                         logger.fine(

--- a/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
+++ b/plugin/src/test/java/hudson/plugins/swarm/SwarmClientIntegrationTest.java
@@ -241,7 +241,7 @@ public class SwarmClientIntegrationTest {
         Assume.assumeFalse(
                 "TODO Windows container agents cannot run this test", Functions.isWindows());
         Path pidFile = getPidFile();
-        Files.writeString(pidFile, Long.toString(66000), StandardCharsets.US_ASCII);
+        Files.writeString(pidFile, "66000", StandardCharsets.US_ASCII);
 
         // PID file should be ignored since the process isn't running.
         swarmClientRule.createSwarmClient("-pidFile", pidFile.toAbsolutePath().toString());


### PR DESCRIPTION
The commit a982063 changed the behavior of the `-pidFile` argument so that the client would exit if a running process was found with the PID listed in the PID file. This was meant to prevent multiple instances of Swarm Client from being started (namely when Swarm Client is launched without a proper service manager that would prevent multiple instances from running).

However, this behavior introduced a dangerous flaw: if Swarm Client does not exit cleanly (because of a sudden reboot, crash, etc) and another process starts with this PID, then Swarm Client will not start at all.

This commit adds a small safety check by comparing the paths of the old and current process. If they are the same, we can assume that the old process is another Swarm Client instance and bail out. But if the paths don't match, we should instead consider the PID file to be stale and continue startup as usual.

---

This behavior was introduced in https://github.com/jenkinsci/swarm-plugin/pull/114, but I only noticed this behavior recently when an unrelated problem caused several of our Mac nodes to reboot, and Swarm Client failed to start afterwards.

---

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] ~Link to relevant issues in GitHub or Jira~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
