### PR TITLE
[JENKINS-70189] Make docs visible from plugins site

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -10,6 +10,7 @@
     <artifactId>swarm</artifactId>
     <packaging>hpi</packaging>
     <name>Swarm Plugin</name>
+    <url>https://github.com/jenkinsci/swarm-plugin</url>
 
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## [JENKINS-70189](https://issues.jenkins.io/browse/JENKINS-70189) Make docs visible from plugins site

[JENKINS-70189](https://issues.jenkins.io/browse/JENKINS-70189) reports that the swarm plugin documentation is not visible from the plugins site at https://plugins.jenkins.io/swarm/ .  The plugins site displays an incorrect URL for the documentation.

The plugins site uses the `url` property from the pom file of the released plugin.  Because the swarm plugin is part of a multi-module project, it needs the `url` property set in the `plugin/pom.xml` file.

Testing performed:

* Built the plugin before this change and confirmed that the plugin/target/swarm.hpi file contains a `pom.xml` file that includes the `url` property with the value `https://github.com/jenkinsci/swarm-plugin/swarm`
* Built the plugin after this change and confirmed that the the plugin/target/swarm.hpi file contains a `pom.xml` file that includes the `url` property with the value `https://github.com/jenkinsci/swarm-plugin`

Once a new release of the plugin is delivered with this change, the https://plugins.jenkins.io/swarm/ page will include the documentation of the plugin instead of the broken link (3-6 hours after release).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
