### PR TITLE
Only use crumbIssuer if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ work
 .settings
 .classpath
 .project
+
+# asdf
+.tool-versions

--- a/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
+++ b/client/src/main/java/hudson/plugins/swarm/LabelFileWatcher.java
@@ -65,8 +65,12 @@ public class LabelFileWatcher implements Runnable {
                         URI.create(url + "plugin/swarm/getSlaveLabels?name=" + name))
                 .GET();
         SwarmClient.addAuthorizationHeader(builder, options);
-        HttpRequest request = builder.build();
         try {
+            SwarmClient.Crumb csrfCrumb = SwarmClient.getCsrfCrumb(client, options, url);
+            if (csrfCrumb != null) {
+                builder.header(csrfCrumb.crumbRequestField, csrfCrumb.crumb);
+            }
+            HttpRequest request = builder.build();
             HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
             if (response.statusCode() != HttpURLConnection.HTTP_OK) {
                 logger.log(

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -71,6 +71,7 @@ public class SwarmClient {
 
     private final Options options;
     private final String hash;
+    private static boolean crumbHeaderNeeded = true;
     private String name;
     private HttpServer prometheusServer = null;
 
@@ -280,9 +281,14 @@ public class SwarmClient {
         }
     }
 
-    private static synchronized Crumb getCsrfCrumb(HttpClient client, Options options, URL url)
+    static synchronized Crumb getCsrfCrumb(HttpClient client, Options options, URL url)
             throws IOException, InterruptedException {
         logger.finer("getCsrfCrumb() invoked");
+
+        // return null if not needed
+        if (!crumbHeaderNeeded) {
+            return null;
+        }
 
         String[] crumbResponse;
 
@@ -356,13 +362,23 @@ public class SwarmClient {
                 + param("keepDisconnectedClients", Boolean.toString(options.keepDisconnectedClients)));
         HttpRequest.Builder builder = HttpRequest.newBuilder(uri).POST(HttpRequest.BodyPublishers.noBody());
         SwarmClient.addAuthorizationHeader(builder, options);
-        Crumb csrfCrumb = getCsrfCrumb(client, options, url);
-        if (csrfCrumb != null) {
-            builder.header(csrfCrumb.crumbRequestField, csrfCrumb.crumb);
-        }
         HttpRequest request = builder.build();
 
         HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        if (response.statusCode() == HttpURLConnection.HTTP_FORBIDDEN) {
+            logger.info("Received HTTP_FORBIDDEN first time - retrying with Crumb...");
+            Crumb csrfCrumb = getCsrfCrumb(client, options, url);
+            if (csrfCrumb != null) {
+                builder.header(csrfCrumb.crumbRequestField, csrfCrumb.crumb);
+            }
+            request = builder.build();
+            response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() != HttpURLConnection.HTTP_FORBIDDEN) {
+                logger.warning("It seems a password is being used to authenticate - please consider using an API token. Password authentication will eventually be DEPRECATED.");
+            }
+        } else {
+            crumbHeaderNeeded = false;
+        }
         if (response.statusCode() != HttpURLConnection.HTTP_OK) {
             throw new RetryException(String.format(
                     "Failed to create a Swarm agent on Jenkins. Response code: %s%n%s",
@@ -630,7 +646,7 @@ public class SwarmClient {
         }
     }
 
-    private static class Crumb {
+    protected static class Crumb {
         final String crumb;
         final String crumbRequestField;
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR removes unneccessary requests to the `/crumbIssuer` endpoint when using an API token.

- the decision of whether a crumb is needed is made at agent creation time
- subsequent calls to sync labels, etc, request the crumb only if needed

### Testing done

- Tested both manually and through adding a test case

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
