### PR TITLE
SwarmClient.java: retry connection if CSRF Crumb was not-received with HTTP-5xx error

### DIFF
--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -281,7 +281,7 @@ public class SwarmClient {
     }
 
     private static synchronized Crumb getCsrfCrumb(HttpClient client, Options options, URL url)
-            throws IOException, InterruptedException {
+            throws IOException, InterruptedException, RetryException {
         logger.finer("getCsrfCrumb() invoked");
 
         String[] crumbResponse;
@@ -299,6 +299,9 @@ public class SwarmClient {
                     String.format(
                             "Could not obtain CSRF crumb. Response code: %s%n%s",
                             response.statusCode(), response.body()));
+            if (response.statusCode() >= 500 && response.statusCode() < 600 && options.retry >= 0)
+                throw new RetryException("Failed to obtain CSRF crumb due to an Internal Server "
+                        + "Error or similar condition. Response code: " + response.statusCode());
             return null;
         }
 

--- a/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
+++ b/client/src/main/java/hudson/plugins/swarm/SwarmClient.java
@@ -299,7 +299,7 @@ public class SwarmClient {
                     String.format(
                             "Could not obtain CSRF crumb. Response code: %s%n%s",
                             response.statusCode(), response.body()));
-            if (response.statusCode() >= 500 && response.statusCode() < 600 && options.retry >= 0)
+            if (response.statusCode() >= 500 && response.statusCode() < 600)
                 throw new RetryException("Failed to obtain CSRF crumb due to an Internal Server "
                         + "Error or similar condition. Response code: " + response.statusCode());
             return null;


### PR DESCRIPTION
As reported in https://issues.jenkins.io/browse/JENKINS-70501 sometimes when the Jenkins controller reboots (and responds with the butler page instead of any logical replies while it is initializing), and the Swarm Client is trying to reconnect, it fails and stalls.

Quoting from that ticket:

> When the controller was last restarting, some swarm agents never re-appeared. Some hours after that I logged in to check on them, and found the last logged interaction was the HTML response about "Starting Jenkins"; a retry after that never happened:

````
# Tail of journal:
Jan 26 14:10:27 nutci-debian-11-amd64 swarm-client-nutci.sh[153]: INFO: Retrying in 10 seconds
Jan 26 14:10:37 nutci-debian-11-amd64 swarm-client-nutci.sh[153]: Jan 26, 2023 2:10:37 PM hudson.plugins.swarm.Client run
Jan 26 14:10:37 nutci-debian-11-amd64 swarm-client-nutci.sh[153]: INFO: Attempting to connect to https://ci.networkupstools.org/
Jan 26 14:10:37 nutci-debian-11-amd64 swarm-client-nutci.sh[153]: Jan 26, 2023 2:10:37 PM hudson.plugins.swarm.SwarmClient getCsrfCrumb
Jan 26 14:10:37 nutci-debian-11-amd64 swarm-client-nutci.sh[153]: SEVERE: Could not obtain CSRF crumb. Response code: 503
Jan 26 14:10:37 nutci-debian-11-amd64 swarm-client-nutci.sh[153]:
Jan 26 14:10:37 nutci-debian-11-amd64 swarm-client-nutci.sh[153]:
Jan 26 14:10:37 nutci-debian-11-amd64 swarm-client-nutci.sh[153]:     <!DOCTYPE html><html lang="en"><head resURL="/static/6728fa46" data-rooturl="" data-resurl="/static/6728fa46" data-imagesurl="/static/6728fa46/images"><title>Starting Jenkins</title><meta name="ROBOTS" content="NOFOLLOW"><meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="/static/6728fa46/jsbundles/simple-page.css" type="text/css"><link rel="stylesheet" href="/static/6728fa46/css/loading.css" type="text/css"></head><body><div class="simple-page" role="main"><div class="modal signup"><div class="signupIntroDefault"><div class="logo"><img src="/static/6728fa46/images/svgs/logo.svg" alt="Jenkins logo"></div><h1 class="loading">
Jan 26 14:10:37 nutci-debian-11-amd64 swarm-client-nutci.sh[153]:                             Please wait while Jenkins is getting ready to work
Jan 26 14:10:37 nutci-debian-11-amd64 swarm-client-nutci.sh[153]:                             <span>.</span><span>.</span><span>.</span></h1><p class="restarting">Your browser will reload automatically when Jenkins is ready.</div></div></div><script src="/static/6728fa46/scripts/loading.js" type="text/javascript"></script></body></html>
^C

:; date
Thu Jan 26 17:36:21 UTC 2023
````

> This is a large inconvenience - to recover I have to log into the workers or have a way to reboot them, after I notice they are AWOL at all. In the meanwhile, the CI farm is under-powered - machines run but executors are not provided by them.

I hope this simple fix would cause the Swarm Client to continue retrying (if enabled by user) until the server begins responding and gives the actual CSRF logic response instead of the "Starting..." HTML page.

### Testing done

At the moment of posting, this is a speculative fix, with a build running on a private CI farm (busy working so not restarting for fun in short term, possibly next week...) to see if the original error would be ever seen again if the server is recycled by auto-packaging updates or other evils.

I wonder if it is possible however that the server would pass through some other interim states during init, characterized by different error codes and messages if queried at that moment. Maybe a more thorough fix would "remember" the timestamp when a server error was seen - possibly with response content parsing to be sure that this was a server start-up, so for some time after that discovery it would cause any other errors to also go to retry.

So far I have no idea for automated testing for this situation and do not intend to spend time on that, but others are welcome to chime in with code :)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
- [x] Reported on manual testing
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
